### PR TITLE
feat: add currency custom field fixture for Bank Account doctype

### DIFF
--- a/admin_panel/fixtures/custom_field.json
+++ b/admin_panel/fixtures/custom_field.json
@@ -1,0 +1,14 @@
+[
+  {
+    "doctype": "Custom Field",
+    "name": "Bank Account-currency",
+    "dt": "Bank Account",
+    "fieldname": "currency",
+    "fieldtype": "Link",
+    "options": "Currency",
+    "label": "Currency",
+    "insert_after": "bank_account_no",
+    "in_list_view": 0,
+    "reqd": 1
+  }
+]

--- a/admin_panel/hooks.py
+++ b/admin_panel/hooks.py
@@ -242,4 +242,5 @@ after_migrate = ["admin_panel.admin_panel.setup.after_migrate"]
 fixtures = [
     {"doctype": "Workspace", "filters": [["module", "=", "Admin Panel"]]},
     {"doctype": "Client Script", "filters": [["module", "=", "Admin Panel"]]},
+    {"doctype": "Custom Field", "filters": [["dt", "=", "Bank Account"], ["fieldname", "=", "currency"]]},
 ]


### PR DESCRIPTION
Currency is not a default type on Bank Account. This adds it fixtures which extends the existing DocType with a custom field.