### PR TITLE
feat: Cashout doctype with .js and .py logic

### DIFF
--- a/admin_panel/admin_panel/doctype/cashout/cashout.js
+++ b/admin_panel/admin_panel/doctype/cashout/cashout.js
@@ -1,0 +1,46 @@
+frappe.ui.form.on('Cashout', {
+
+	onload: function(frm) {
+		if (frm.doc.customer) {
+			frm.set_query('bank_account', () => ({
+				filters: [
+					['Bank Account', 'party_type', '=', 'Customer'],
+					['Bank Account', 'party', '=', frm.doc.customer]
+				]
+			}));
+		}
+	},
+
+	customer: function(frm) {
+		frm.set_value('bank_account', null);
+		frm.set_query('bank_account', () => ({
+			filters: [
+				['Bank Account', 'party_type', '=', 'Customer'],
+				['Bank Account', 'party', '=', frm.doc.customer]
+			]
+		}));
+	},
+
+	refresh: function(frm) {
+		if (
+			frm.doc.docstatus === 1 &&
+			frm.doc.status === 'In Progress' &&
+			!frm.doc.payment_journal_entry
+		) {
+			frm.add_custom_button('Mark as Completed', () => {
+				frappe.confirm(
+					'Are you sure you want to mark this cashout as Completed and create a Payment Journal Entry?',
+					() => {
+						frappe.call({
+							method: 'create_payment_journal_entry',
+							doc: frm.doc,
+							callback: function(r) {
+								frm.reload_doc();
+							}
+						});
+					}
+				);
+			}, 'Actions');
+		}
+	}
+});

--- a/admin_panel/admin_panel/doctype/cashout/cashout.json
+++ b/admin_panel/admin_panel/doctype/cashout/cashout.json
@@ -1,0 +1,164 @@
+{
+ "actions": [],
+ "creation": "2026-05-04 00:00:00.000000",
+ "custom": 0,
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "customer",
+  "bank_account",
+  "status",
+  "transaction_id",
+  "offer_section",
+  "user_pays",
+  "flash_fee",
+  "exchange_rate",
+  "offer_col_break",
+  "user_receives",
+  "currency",
+  "accounting_section",
+  "journal_entry",
+  "wallet_id",
+  "flash_wallet",
+  "payment_journal_entry",
+  "remarks"
+ ],
+ "fields": [
+  {
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Customer",
+   "options": "Customer",
+   "reqd": 1
+  },
+  {
+   "fieldname": "bank_account",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Bank Account",
+   "options": "Bank Account",
+   "reqd": 1
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Draft\nIn Progress\nCompleted"
+  },
+  {
+   "description": "The transaction ID that initiated this cashout",
+   "fieldname": "transaction_id",
+   "fieldtype": "Data",
+   "label": "Transaction ID"
+  },
+  {
+   "collapsible": 1,
+   "collapsed": 1,
+   "fieldname": "offer_section",
+   "fieldtype": "Section Break",
+   "label": "Offer Details"
+  },
+  {
+   "description": "Total USD paid by the user (payout + service fee)",
+   "fieldname": "user_pays",
+   "fieldtype": "Float",
+   "label": "User Paid (USD)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "flash_fee",
+   "fieldtype": "Float",
+   "label": "Flash Fee (USD)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "offer_col_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "user_receives",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "User Receives",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Select",
+   "label": "Currency",
+   "options": "USD\nJMD",
+   "read_only": 1
+  },
+  {
+   "fieldname": "exchange_rate",
+   "fieldtype": "Float",
+   "label": "Exchange Rate (to USD)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "accounting_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting"
+  },
+  {
+   "fieldname": "journal_entry",
+   "fieldtype": "Link",
+   "label": "Payable Journal Entry",
+   "options": "Journal Entry",
+   "read_only": 1
+  },
+  {
+   "fieldname": "wallet_id",
+   "fieldtype": "Data",
+   "label": "User Wallet ID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "flash_wallet",
+   "fieldtype": "Data",
+   "label": "Flash Wallet",
+   "read_only": 1
+  },
+  {
+   "fieldname": "payment_journal_entry",
+   "fieldtype": "Link",
+   "label": "Payment Journal Entry",
+   "options": "Journal Entry",
+   "read_only": 1
+  },
+  {
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "label": "Remarks"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2026-05-06 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Admin Panel",
+ "name": "Cashout",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "cancel": 1,
+   "create": 1,
+   "read": 1,
+   "role": "Accounts Manager",
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/admin_panel/admin_panel/doctype/cashout/cashout.py
+++ b/admin_panel/admin_panel/doctype/cashout/cashout.py
@@ -1,0 +1,136 @@
+import frappe
+from frappe.model.document import Document
+
+
+@frappe.whitelist()
+def submit_cashout(name):
+	frappe.get_doc("Cashout", name).submit()
+
+
+class Cashout(Document):
+
+	def validate(self):
+		bank_account = frappe.get_doc("Bank Account", self.bank_account)
+		if bank_account.party_type != "Customer" or bank_account.party != self.customer:
+			frappe.throw("Bank Account does not belong to the selected Customer.")
+
+		# account_currency = frappe.get_value("Account", bank_account.account, "account_currency")
+		# self.currency = account_currency or "USD"
+
+	def after_insert(self):
+		self.create_payable_journal_entry()
+
+	def before_submit(self):
+		if not self.transaction_id:
+			frappe.throw("Transaction ID is required before submitting.")
+
+	def on_submit(self):
+		je = frappe.get_doc("Journal Entry", self.journal_entry)
+		je.submit()
+		self.db_set("status", "In Progress")
+
+	def create_payable_journal_entry(self):
+		company = frappe.defaults.get_user_default("Company")
+
+		is_jmd = self.currency == "JMD"
+
+		je = frappe.get_doc({
+			"doctype": "Journal Entry",
+			"voucher_type": "Journal Entry",
+			"company": company,
+			"multi_currency": 1,
+			"posting_date": frappe.utils.today(),
+			"user_remark": f'{{"transactionId": "{self.transaction_id}", "walletId": "{self.wallet_id}"}}',
+			"accounts": [
+				{
+					"account": "Ibex Operating - F",
+					"account_currency": "USD",
+					"debit_in_account_currency": self.user_pays,
+					"debit": self.user_pays,
+					"exchange_rate": 1,
+				},
+				{
+					"account": f"Cashout Payables ({self.currency}) - F",
+					"account_currency": self.currency,
+					"credit_in_account_currency": self.user_receives,
+					"credit": self.user_receives / self.exchange_rate if is_jmd else self.user_receives,
+					"exchange_rate": 1 / self.exchange_rate if is_jmd else 1,
+					# "party_type": "Customer",
+					# "party": self.customer,
+				},
+				{
+					"account": "Service Fees - F",
+					"account_currency": "USD",
+					"credit_in_account_currency": self.flash_fee,
+					"credit": self.flash_fee,
+					"exchange_rate": 1,
+				},
+			]
+		})
+
+		je.insert(ignore_permissions=True)
+		self.db_set("journal_entry", je.name, update_modified=False)
+
+	@frappe.whitelist()
+	def create_payment_journal_entry(self):
+		if self.payment_journal_entry:
+			frappe.throw("Payment Journal Entry already exists.")
+
+		if self.status != "In Progress":
+			frappe.throw("Cashout must be In Progress before marking as Completed.")
+
+		company = frappe.defaults.get_user_default("Company")
+		is_jmd = self.currency == "JMD"
+
+		bank_accounts = frappe.get_all(
+			"Bank Account",
+			filters={"company": company, "is_company_account": 1},
+			fields=["account"]
+		)
+		company_bank_account = next(
+			(ba.account for ba in bank_accounts
+			 if frappe.get_value("Account", ba.account, "account_currency") == self.currency),
+			None
+		)
+		if not company_bank_account:
+			frappe.throw(f"No company Bank Account found for currency {self.currency}.")
+
+		payout_entry = {
+			"account_currency": self.currency,
+			"debit_in_account_currency": self.user_receives,
+			"credit_in_account_currency": 0,
+			"debit": self.user_receives / self.exchange_rate if is_jmd else self.user_receives,
+			"exchange_rate": 1 / self.exchange_rate if is_jmd else 1,
+		}
+
+		je = frappe.get_doc({
+			"doctype": "Journal Entry",
+			"voucher_type": "Bank Entry",
+			"company": company,
+			"multi_currency": 1,
+			"posting_date": frappe.utils.today(),
+			"user_remark": f'{{"transactionId": "{self.transaction_id}", "walletId": "{self.wallet_id}"}}',
+			"accounts": [
+				{
+					**payout_entry,
+					"account": f"Cashout Payables ({self.currency}) - F",
+					# "party_type": "Customer",
+					# "party": self.customer,
+				},
+				{
+					**payout_entry,
+					"account": company_bank_account,
+					"debit_in_account_currency": 0,
+					"debit": 0,
+					"credit_in_account_currency": self.user_receives,
+					"credit": self.user_receives / self.exchange_rate if is_jmd else self.user_receives,
+				},
+			]
+		})
+
+		je.insert(ignore_permissions=True)
+		je.submit()
+
+		self.db_set("payment_journal_entry", je.name)
+		self.db_set("status", "Completed")
+		frappe.msgprint(f"Payment Journal Entry {je.name} created.")

--- a/admin_panel/api/admin_api.py
+++ b/admin_panel/api/admin_api.py
@@ -344,3 +344,15 @@ def get_id_document_url(file_key):
 		return {"success": False, "errors": error_messages}
 
 	return {"success": True, "url": result.get('readUrl')}
+
+
+@frappe.whitelist()
+def get_customer_bank_accounts(customer):                                                               
+		accounts = frappe.get_all(                                                                          
+				"Bank Account",
+				filters={"party_type": "Customer", "party": customer},                                          
+				fields=["name", "account_name", "bank", "bank_account_no", "account"],                          
+		)
+		for acct in accounts:                                                                               
+				acct["currency"] = frappe.get_value("Account", acct["account"], "account_currency")             
+		return accounts


### PR DESCRIPTION
- Cashout DocType contains the base details of the cashout plus state tracking the progress of a cashout. 
- the .py manages the lifecycle of the Cashout. A JournalEntry is drafted when a Cashout is drafted. The Journal Entry is submitted when the Cashout is submitted (`In Progress`)



