### PR TITLE
ci: add release script and document release flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ bench --site {site} export-fixtures --app admin_panel
 
 This updates `admin_panel/fixtures/workspace.json` and `admin_panel/fixtures/client_script.json`.
 
+### Releasing
+
+Releases are versioned with git tags and published as a multi-arch Docker image (`brh28/frappe-flash`).
+
+**Local release flow:**
+```bash
+./release.sh <major|minor|patch>
+```
+This bumps the version from the last git tag, creates a new tag, pushes it to the remote, and builds and pushes the Docker image.
+
+**CI flow:**
+
+A push of a version tag (e.g. `v1.2.0`) triggers CI, which runs `ci.sh` directly to build and push the image. `release.sh` is not involved.
+
+**Version bump guide:**
+- `patch` — bug fixes
+- `minor` — new features
+- `major` — breaking changes
+
 ### Contributing
 
 This app uses `pre-commit` for code formatting and linting. Please [install pre-commit](https://pre-commit.com/#installation) and enable it for this repository:

--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 REPO="brh28/frappe-flash"
-TAG="${1:?Usage: ./ci.sh <version>}"
+
+TAG="$(git describe --tags --exact-match HEAD 2>/dev/null)" || {
+  echo "Error: HEAD is not tagged. Tag the commit first (e.g. git tag v1.2.0)." >&2
+  exit 1
+}
 
 docker buildx build \
   --no-cache \

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUMP="${1:?Usage: ./release.sh <major|minor|patch>}"
+
+LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')"
+if [[ -z "$LAST_TAG" ]]; then
+  echo "Error: no existing tags found." >&2
+  exit 1
+fi
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_TAG"
+
+case "$BUMP" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+  *) echo "Error: bump must be major, minor, or patch." >&2; exit 1 ;;
+esac
+
+NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+
+echo "Last tag: v${LAST_TAG}"
+echo "New tag:  ${NEW_TAG}"
+read -rp "Proceed? [y/N] " CONFIRM
+[[ "$CONFIRM" =~ ^[Yy]$ ]] || exit 0
+
+git tag "$NEW_TAG"
+git push origin "$NEW_TAG"
+
+./ci.sh


### PR DESCRIPTION
Adds release.sh to automate version bumping, git tagging, and Docker image builds. Updates ci.sh to derive version from git tag automatically. Documents the full release and CI flow in README.md.

