### PR TITLE
typing: parameterize GraphQL extraction

### DIFF
--- a/admin_panel/api/graphql_client.py
+++ b/admin_panel/api/graphql_client.py
@@ -1,8 +1,11 @@
-import requests
+import time
+from typing import TypeVar, cast
+
 import frappe
 import jwt
-import time
-from typing import Any
+import requests
+
+ExtractedData = TypeVar("ExtractedData")
 
 
 class GraphQLError(Exception):
@@ -80,13 +83,15 @@ class GraphQLClient:
 		response.raise_for_status()
 		return response.json()
 
-	def execute_and_extract(self, query: str, variables: dict, data_key: str, allow_not_found: bool = False) -> Any:
+	def execute_and_extract(
+		self, query: str, variables: dict, data_key: str, allow_not_found: bool = False
+	) -> ExtractedData | None:
 		"""Execute query, check errors, and extract data by key"""
 		resp = self.execute_query(query, variables)
 		self._check_errors(resp, allow_not_found)
 		if allow_not_found and resp.get('errors'):
 			return None
-		return resp.get("data", {}).get(data_key)
+		return cast(ExtractedData | None, resp.get("data", {}).get(data_key))
 	
 	# GraphQL query constants
 	ACCOUNT_BY_PHONE_QUERY = """


### PR DESCRIPTION
Fixes #16.

Summary:
- replace the unbounded Any return on execute_and_extract with a type parameter
- cast the extracted GraphQL data to ExtractedData | None at the boundary
- preserve existing allow_not_found behavior and call sites

Validation:
- python -c "import ast, pathlib; ast.parse(pathlib.Path(''admin_panel/api/graphql_client.py'').read_text()); print(''syntax ok'')"
- git diff --check

Note: python -m py_compile was not usable in this Windows shell because it failed while trying to write admin_panel\api\__pycache__; the AST parse check verifies syntax without writing bytecode.

Payout route if needed: 0xB34D185318b34ec2F9E060F662Cc7feA3180049c