### PR TITLE
fix: set party on cashout payable entries

### DIFF
--- a/admin_panel/admin_panel/doctype/cashout/cashout.py
+++ b/admin_panel/admin_panel/doctype/cashout/cashout.py
@@ -56,8 +56,8 @@ class Cashout(Document):
 					"credit_in_account_currency": self.user_receives,
 					"credit": self.user_receives / self.exchange_rate if is_jmd else self.user_receives,
 					"exchange_rate": 1 / self.exchange_rate if is_jmd else 1,
-					# "party_type": "Customer",
-					# "party": self.customer,
+					"party_type": "Customer",
+					"party": self.customer,
 				},
 				{
 					"account": settings.service_fees_account,
@@ -123,8 +123,8 @@ class Cashout(Document):
 				{
 					**payout_entry,
 					"account": payables_account,
-					# "party_type": "Customer",
-					# "party": self.customer,
+					"party_type": "Customer",
+					"party": self.customer,
 				},
 				{
 					**payout_entry,


### PR DESCRIPTION
## Summary
- set Customer party metadata on the Cashout payable journal-entry row
- set the same Customer party metadata when clearing the payable through the payment journal entry

## Context
ERPNext rejects Journal Entry rows for Receivable / Payable accounts unless both Party Type and Party are provided. Local cashout initiation was failing with `Party Type and Party is required for Receivable / Payable account Cashout Payables (JMD) - F` when the Flash backend tried to complete the cashout flow.

## Testing
- `python3 -m py_compile admin_panel/admin_panel/doctype/cashout/cashout.py`
- `uvx ruff check admin_panel/admin_panel/doctype/cashout/cashout.py`
- `git diff --check`