### PR TITLE
Show remarks on transfer request details

### DIFF
--- a/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
+++ b/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
@@ -450,6 +450,10 @@ class TransferRequestsManager {
                     font-weight: 500;
                 }
 
+                .flash-cashout-manager .detail-remarks {
+                    white-space: pre-wrap;
+                }
+
                 .flash-cashout-manager .detail-link {
                     color: var(--color-primary);
                     text-decoration: none;
@@ -782,6 +786,12 @@ class TransferRequestsManager {
                                     <div class="detail-item">
                                         <span class="detail-label">Last Modified</span>
                                         <span class="detail-value detail-modified"></span>
+                                    </div>
+                                </div>
+                                <div class="col-md-12">
+                                    <div class="detail-item">
+                                        <span class="detail-label">Remarks</span>
+                                        <span class="detail-value detail-remarks"></span>
                                     </div>
                                 </div>
                             </div>
@@ -1237,6 +1247,7 @@ class TransferRequestsManager {
         panel.find('.detail-request-id').text(req.name || '-');
         panel.find('.detail-submitted').text(this.formatDateTime(req.creation));
         panel.find('.detail-modified').text(this.formatDateTime(req.modified));
+        panel.find('.detail-remarks').text(req.remarks || '-');
 
         const createBtn = panel.find('.btn-create-cashout');
         const confirmBtn = panel.find('.btn-confirm-payment');

--- a/admin_panel/tests/test_transfer_requests_page_contract.py
+++ b/admin_panel/tests/test_transfer_requests_page_contract.py
@@ -149,3 +149,11 @@ def test_cashout_payment_bank_entry_sets_required_reference_fields():
     assert '"cheque_no": payment_reference_no' in cashout_py
     assert '"cheque_date": payment_reference_date' in cashout_py
     assert "doc.create_payment_journal_entry(reference_no=confirmation_code" in api_py
+
+
+def test_cashout_details_render_remarks_from_cashout_record():
+    js = read_text(PAGE_DIR / "transfer_requests.js")
+
+    assert '<span class="detail-label">Remarks</span>' in js
+    assert "detail-remarks" in js
+    assert "panel.find('.detail-remarks').text(req.remarks || '-')" in js


### PR DESCRIPTION
## Summary
- Adds the Cashout/Bridge transfer request `remarks` field to the Transfer Requests detail panel.
- Preserves line breaks in remarks text.
- Extends the page contract test to cover the remarks row and binding.

## Verification
- `git diff --check`
- `pytest admin_panel/tests/test_transfer_requests_page_contract.py -q` — 13 passed.