### PR TITLE
ci: add pre-commit workflow (changed-files scope)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, feat/cashout-requests-page]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    name: pre-commit (changed files)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the PR base/head commits are available for the diff.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit on files changed in this PR
+        run: |
+          pre-commit run \
+            --from-ref "${{ github.event.pull_request.base.sha }}" \
+            --to-ref "${{ github.event.pull_request.head.sha }}" \
+            --show-diff-on-failure \
+            --color=always


### PR DESCRIPTION
The repo had **no GitHub Actions CI** — the existing `.pre-commit-config.yaml` (ruff lint/format, prettier, eslint, AST/json/yaml checks) only ran locally for devs who had pre-commit installed, so PRs (incl. the Bridge cashout admin pages #35/#36) merged with zero automated checks. `ci.sh` is a release/build script, not PR validation, and there's no test suite.

## What this adds
A single `pre-commit` job on PRs into `main` and `feat/cashout-requests-page`, reusing the existing hook config. **Scoped to the files changed in each PR** (`pre-commit run --from-ref <base> --to-ref <head>`), so it gates new work without going red on pre-existing repo-wide lint debt.

- Actions pinned to current majors (`checkout@v4`, `setup-python@v5`) — avoids the Node-20 deprecation warnings.
- `concurrency` cancels superseded runs on the same PR.
- Python 3.10 to match `pyproject.toml` (`target-version = "py310"`).

## Notes
- **Propagation:** the workflow lives on `main`, so PRs into `main` are gated once this merges. PR #36 (base `feat/cashout-requests-page`) will be gated once this reaches that branch (merge `main` in / rebase).
- **Whole-repo cleanup** (running `pre-commit run --all-files` and fixing accumulated debt) is intentionally out of scope — can be a follow-up if you want full enforcement.
- No test job, since the repo has no tests. Wiring up Frappe `bench run-tests` would be a separate effort.
- This PR self-validates: pre-commit runs against its own changed file (`ci.yml`) — `check-yaml` should pass it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)