### PR TITLE
ci: publish image to ghcr.io/lnflash on tag push + sync deployments

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,136 @@
+name: Publish image & sync deployments
+
+# Replaces the manual laptop release flow (ci.sh -> brh28 Docker Hub):
+# push a v* tag and this builds ghcr.io/lnflash/frappe-flash:<tag>
+# (amd64 + arm64, native runners), then opens a deployments PR bumping
+# the erp terraform values so `make erp ENV=<env>` pulls it.
+# The actual terraform apply stays manual — this pipeline stops at the PR.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/lnflash/frappe-flash
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build & push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/${{ matrix.arch }}
+          # The Dockerfile installs the app FROM GIT at this ref (bench
+          # get-app --branch), so the image content is the tagged commit,
+          # not the checkout.
+          build-args: BRANCH=${{ github.ref_name }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,push=true
+          no-cache: true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Create multi-arch manifest (tag + latest)
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          refs=""
+          for d in *; do refs="$refs ${IMAGE}@sha256:${d}"; done
+          docker buildx imagetools create -t "${IMAGE}:${{ github.ref_name }}" $refs
+          docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}:${{ github.ref_name }}"
+          docker buildx imagetools inspect "${IMAGE}:${{ github.ref_name }}"
+
+  sync-deployments:
+    needs: merge-manifest
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open deployments bump PR
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOYMENTS_PAT }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::DEPLOYMENTS_PAT secret not set — skipping the deployments bump PR." \
+              "Add the PAT (repo scope on lnflash/deployments) to enable full automation;" \
+              "until then bump tf-modules/erp/values.base.yaml manually to ${VERSION}."
+            exit 0
+          fi
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/lnflash/deployments.git" dep
+          cd dep
+          values="tf-modules/erp/values.base.yaml"
+          current="$(grep -m1 -E '^\s*tag:' "$values" | sed -E 's/.*tag:\s*"?(v[0-9.]+)"?.*/\1/')"
+          if [ "$current" = "$VERSION" ]; then
+            echo "deployments already at ${VERSION}; nothing to do"
+            exit 0
+          fi
+          branch="chore/bump-erp-image-${VERSION}"
+          git config user.email "bot@flash.io"
+          git config user.name "CI Bot"
+          git checkout -b "$branch"
+          # Bump the image tag: field and any fully-qualified image refs.
+          sed -i -E "s|(tag:\s*\"?)${current}(\"?)|\1${VERSION}\2|" "$values"
+          sed -i -E "s|(ghcr\.io/lnflash/frappe-flash:)${current}|\1${VERSION}|g" "$values"
+          git add "$values"
+          git commit -m "chore(erp): bump frappe-flash image ${current} -> ${VERSION}"
+          git push -u origin "$branch"
+          gh pr create --repo lnflash/deployments \
+            --title "chore(erp): bump frappe-flash image to ${VERSION}" \
+            --body "Automated: ghcr.io/lnflash/frappe-flash:${VERSION} was published. Merge, then apply with \`make erp ENV=<env>\` on the jumpbox." \
+            --head "$branch"

--- a/ci.sh
+++ b/ci.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="brh28/frappe-flash"
+# Local fallback only — the publish-image GitHub workflow is the normal path
+# (builds on v* tag push). Requires a PAT with packages:write for ghcr login.
+REPO="ghcr.io/lnflash/frappe-flash"
 
 TAG="$(git describe --tags --exact-match HEAD 2>/dev/null)" || {
   echo "Error: HEAD is not tagged. Tag the commit first (e.g. git tag v1.2.0)." >&2

--- a/release.sh
+++ b/release.sh
@@ -28,4 +28,6 @@ read -rp "Proceed? [y/N] " CONFIRM
 git tag "$NEW_TAG"
 git push origin "$NEW_TAG"
 
-./ci.sh
+echo "Tag pushed — the publish-image workflow now builds and pushes"
+echo "ghcr.io/lnflash/frappe-flash:${NEW_TAG} and opens the deployments bump PR."
+echo "Watch: https://github.com/lnflash/frappe-flash-admin/actions"


### PR DESCRIPTION
## Summary
Puts the ERP image on the same CI/CD footing as the flash chart:

- **Tag push `v*` → GitHub Actions builds** `ghcr.io/lnflash/frappe-flash:<tag>` (amd64 + arm64 on native runners, multi-arch manifest, `:latest` alias). No more laptop builds to the `brh28` personal Docker Hub.
- **Auto-opens the deployments bump PR** (`tf-modules/erp/values.base.yaml` → new tag), mirroring the proven `publish-flash-chart` pattern. Needs the `DEPLOYMENTS_PAT` secret added to this repo (same PAT charts uses); until then the step warns and skips — the image publish itself needs no secrets (built-in `GITHUB_TOKEN`).
- `release.sh` becomes tag-and-push only; `ci.sh` kept as a documented local fallback, retargeted at the org registry.
- The terraform apply stays deliberate/manual (`make erp ENV=<env>`, target added in the companion deployments PR).

## Notes
- The Dockerfile installs the app **from git at the tag** (`bench get-app --branch`), so the built image is the tagged commit regardless of checkout — the workflow passes `BRANCH=<tag>` explicitly.
- Companion deployments PR migrates `values.base.yaml` off `brh28/frappe-flash` (currently pinned at v1.4.0 while the cluster runs v1.5.0 — live drift this pipeline exists to prevent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)