### PR TITLE
fix: lookups tolerate partial GraphQL responses (broken-field accounts)

### DIFF
--- a/admin_panel/api/graphql_client.py
+++ b/admin_panel/api/graphql_client.py
@@ -96,11 +96,32 @@ class GraphQLClient:
 	def execute_and_extract(
 		self, query: str, variables: dict, data_key: str, allow_not_found: bool = False
 	) -> Any:
-		"""Execute query, check errors, and extract data by key"""
+		"""Execute query, check errors, and extract data by key.
+
+		allow_not_found selects LOOKUP semantics, which also tolerate PARTIAL
+		responses: when the requested node resolved, field-level resolver
+		errors (e.g. owner.email failing with a Kratos 404 on a dangling
+		identity, seen on TEST 2026-07-11) must not void the whole account —
+		the admin panel exists precisely to inspect broken accounts. The
+		errors are logged and the failed fields arrive as null.
+
+		Without the flag (mutations, strict reads) semantics stay
+		all-or-nothing: any GraphQL error raises.
+		"""
 		resp = self.execute_query(query, variables)
-		self._check_errors(resp, allow_not_found)
-		if allow_not_found and resp.get("errors"):
+		if allow_not_found:
+			data = (resp.get("data") or {}).get(data_key)
+			errors = resp.get("errors")
+			if data is not None:
+				if errors:
+					frappe.logger().warning(
+						f"GraphQL partial response for {data_key} (using data, "
+						f"failed fields are null): {errors}"
+					)
+				return data
+			self._check_errors(resp, allow_not_found=True)
 			return None
+		self._check_errors(resp)
 		return resp.get("data", {}).get(data_key)
 
 	# GraphQL query constants

--- a/admin_panel/tests/test_account_hub_search_js.py
+++ b/admin_panel/tests/test_account_hub_search_js.py
@@ -60,3 +60,13 @@ def test_graphql_client_treats_invalid_account_id_as_not_found():
 	assert "_is_not_found_error" in client_py
 	assert "InvalidAccountIdError" in client_py
 	assert "UNEXPECTED_CLIENT_ERROR" in client_py
+
+
+def test_graphql_client_lookups_tolerate_partial_responses():
+	"""A resolved account node with field-level errors (e.g. Kratos 404 on
+	owner.email) must be returned with nulls, not raised — the admin panel
+	exists to inspect broken accounts."""
+	client_py = (ACCOUNT_HUB_JS.parents[3] / "api" / "graphql_client.py").read_text()
+
+	assert "GraphQL partial response" in client_py
+	assert "if allow_not_found:" in client_py


### PR DESCRIPTION
Third failure mode behind the Account Hub 'Could not reach the server' toast (after #41): searching `dread` on TEST — a REAL account whose Kratos identity is gone — dies at `accountDetailsByUsername.owner.email` with `UnknownKratosError: 404`, and the client treated any GraphQL error as total failure.

**Fix:** `allow_not_found` (lookup semantics) now returns the resolved node when present, logging field-level errors — broken fields arrive as null and the account renders. Mutations (level/status updates route through the same helper) keep strict all-or-nothing semantics.

Support-wise this is the right default: an account with a dangling identity is exactly the one an operator needs to open.

Flash-side root cause (owner.email resolver should tolerate a missing Kratos identity) filed separately.

Gates: ruff/format clean, 18 passed (3 pre-existing stale failures documented in #41 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)