### PR TITLE
fix: paginate the IBEX sweep until an empty page, never a short one

### DIFF
--- a/admin_panel/api/census_core.py
+++ b/admin_panel/api/census_core.py
@@ -20,6 +20,30 @@ ACTIVE_STATUS = "active"
 MIGRATED_STATUSES = {"completed", "complete", "succeeded", "success", "done"}
 
 
+class PageLimitExceeded(Exception):
+	"""sweep_pages hit max_pages — the API is paging forever or the cap is too low."""
+
+
+def sweep_pages(fetch_page, max_pages):
+	"""Yield (page_number, batch) from successive 1-indexed pages until an EMPTY page.
+
+	Termination must NOT infer "last page" from a short batch: the prod IBEX
+	hub silently caps the page size (requesting limit=100 returns 25 rows), so
+	a short page looks identical to a full one there. That inference truncated
+	the first prod census to 25 of ~8,750 accounts (2026-07-10). Only an empty
+	page ends the sweep — costing exactly one extra request.
+	"""
+	page = 1
+	while True:
+		if page > max_pages:
+			raise PageLimitExceeded(f"pagination exceeded {max_pages} pages — aborting sweep")
+		batch = fetch_page(page)
+		if not batch:
+			return
+		yield page, batch
+		page += 1
+
+
 def _is_migrated(migration) -> bool:
 	if not migration:
 		return False

--- a/admin_panel/api/ibex_client.py
+++ b/admin_panel/api/ibex_client.py
@@ -24,6 +24,8 @@ import time
 import frappe
 import requests
 
+from .census_core import PageLimitExceeded, sweep_pages
+
 # Verified URLs per environment (from the ibex-client library). Any field can
 # still be overridden via config for a bespoke staging setup. Note the sandbox
 # audience is a different host from production.
@@ -193,23 +195,25 @@ class IbexClient:
 	def iter_all_accounts(self, progress_cb=None):
 		"""Yield every org account across all pages, pacing between requests.
 
-		progress_cb(pages_done, accounts_seen) is called after each page so the
-		caller can persist scan progress for the UI.
+		Pages until an EMPTY page via census_core.sweep_pages — the prod hub
+		silently caps the page size (limit=100 returns 25), so a short batch
+		must never be read as "last page". progress_cb(pages_done,
+		accounts_seen) is called after each page so the caller can persist
+		scan progress for the UI.
 		"""
-		page = 1
+
+		def fetch(page):
+			if page > 1:
+				time.sleep(REQUEST_INTERVAL_SECONDS)
+			return self.list_accounts_page(page, PAGE_LIMIT)
+
 		seen = 0
-		while True:
-			if page > MAX_PAGES:
-				raise IbexError("IBEX account list exceeded MAX_PAGES — aborting scan")
-			batch = self.list_accounts_page(page, PAGE_LIMIT)
-			if not batch:
-				break
-			for account in batch:
-				seen += 1
-				yield account
-			if progress_cb:
-				progress_cb(page, seen)
-			if len(batch) < PAGE_LIMIT:
-				break
-			page += 1
-			time.sleep(REQUEST_INTERVAL_SECONDS)
+		try:
+			for page, batch in sweep_pages(fetch, MAX_PAGES):
+				for account in batch:
+					seen += 1
+					yield account
+				if progress_cb:
+					progress_cb(page, seen)
+		except PageLimitExceeded as exc:
+			raise IbexError(str(exc)) from exc

--- a/admin_panel/tests/test_census_core.py
+++ b/admin_panel/tests/test_census_core.py
@@ -178,3 +178,40 @@ def test_ibex_only_run_is_unmatched_not_closed():
 	# totals still computed from IBEX alone
 	assert result["totals"]["usdt"]["balance"] == 3.0
 	assert result["totals"]["funded"] == 1
+
+
+def test_sweep_pages_continues_past_short_pages():
+	"""Prod IBEX silently caps page size (limit=100 returns 25), so a short
+	batch must NOT be read as the last page — that truncated the first prod
+	census to 25 of ~8,750 accounts. Only an empty page ends the sweep."""
+	from admin_panel.api.census_core import sweep_pages
+
+	pages = {1: ["a"] * 25, 2: ["b"] * 25, 3: ["c"] * 7, 4: []}
+	fetched = []
+
+	def fetch(page):
+		fetched.append(page)
+		return pages[page]
+
+	out = [(p, len(batch)) for p, batch in sweep_pages(fetch, max_pages=10)]
+
+	assert out == [(1, 25), (2, 25), (3, 7)]
+	assert fetched == [1, 2, 3, 4]  # exactly one extra (empty) request
+
+
+def test_sweep_pages_raises_at_max_pages():
+	from admin_panel.api.census_core import PageLimitExceeded, sweep_pages
+
+	def endless(page):
+		return ["x"]
+
+	import pytest
+
+	with pytest.raises(PageLimitExceeded):
+		list(sweep_pages(endless, max_pages=3))
+
+
+def test_sweep_pages_empty_first_page():
+	from admin_panel.api.census_core import sweep_pages
+
+	assert list(sweep_pages(lambda p: [], max_pages=5)) == []

--- a/docs/wallet-census.md
+++ b/docs/wallet-census.md
@@ -66,6 +66,10 @@ query).
   on the Lightning side and is **not** returned here — BTC wallets are counted
   but their balance is reported as `null`, intentionally.
 - The scan paces ~1 req/s and refetches the token once on a `401`.
+- **Prod caps the page size silently**: requesting `limit=100` returns 25 rows
+  (sandbox honors 100). Pagination therefore terminates only on an **empty
+  page**, never on a short one — a short-page inference truncated the first
+  prod census to 25 of ~8,750 accounts.
 
 ### Customer MongoDB (`galoy`)
 


### PR DESCRIPTION
First prod census returned **25 of ~8,750 accounts**: the prod IBEX hub silently caps `limit=100` to 25 rows/page (docs claim [10,100]; the cutover scripts always used limit=25 and saw ~350 pages — consistent). The client's short-batch⇒last-page inference stopped after page 1. Sandbox couldn't expose it: its org has exactly 25 accounts, so the short page really was the last one on TEST.

**Fix:** pagination extracted to `census_core.sweep_pages` (pure, frappe-free): terminates **only on an empty page** (costs one extra request), `PageLimitExceeded` at the MAX_PAGES backstop. `ibex_client.iter_all_accounts` wraps it with pacing + progress callbacks. Three unit tests incl. the exact regression (short page mid-sweep must continue).

Docs updated with the prod-cap fact.

Gates: 18/18 green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)