### PR TITLE
fix: upgrade-requests tile scrolls instead of hash-routing

### DIFF
--- a/admin_panel/admin_panel/page/admin_dashboard/admin_dashboard.js
+++ b/admin_panel/admin_panel/page/admin_dashboard/admin_dashboard.js
@@ -387,7 +387,7 @@ class OpsDashboard {
                 <div class="fp-value">${this.esc(co.count)}</div>
                 <div class="fp-foot">${coChip}</div>
             </a>
-            <a class="fp-tile fp-rise" href="#fp-requests-anchor">
+            <a class="fp-tile fp-rise" href="#" data-scroll="#fp-requests">
                 <div class="fp-label">Upgrade requests pending</div>
                 <div class="fp-value">${this.esc(up.count)}</div>
                 <div class="fp-foot">${upChip}</div>
@@ -396,9 +396,15 @@ class OpsDashboard {
 
 		// desk router for the tile links (keep SPA navigation)
 		$m.find(".fp-tile").on("click", function (e) {
+			e.preventDefault();
+			const scroll = $(this).data("scroll");
+			if (scroll) {
+				const el = document.querySelector(scroll);
+				if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+				return;
+			}
 			const href = $(this).attr("href");
 			if (href && href.startsWith("/app/")) {
-				e.preventDefault();
 				frappe.set_route(href.replace("/app/", ""));
 			}
 		});

--- a/admin_panel/tests/test_wallet_census_page_contract.py
+++ b/admin_panel/tests/test_wallet_census_page_contract.py
@@ -107,3 +107,6 @@ def test_dashboard_renders_pulse_layer():
 	assert "admin_panel.api.admin_api.get_dashboard_stats" in js
 	assert "account_hub_query" in js
 	assert "ad-smart-search" in js
+	# hash hrefs get eaten by the desk router ("Page #x not found") — tiles
+	# must use data-scroll or /app/ routes
+	assert 'href="#fp-' not in js


### PR DESCRIPTION
The 4th pulse tile's `href="#fp-requests-anchor"` was intercepted by the desk router → **"Page #fp-requests-anchor not found"** (repro'd on TEST v1.9.0). Now: `data-scroll` + `scrollIntoView`, tiles always `preventDefault`, and a contract assertion bans `href="#fp-…"` from shipping again. 23/23 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)