### PR TITLE
Ops-pulse design system rollout: every desk page, with queue instrumentation

### DIFF
--- a/admin_panel/admin_panel/doctype/cashout/cashout.py
+++ b/admin_panel/admin_panel/doctype/cashout/cashout.py
@@ -159,4 +159,3 @@ class Cashout(Document):
 		audit_log(
 			"complete_cashout", "Cashout", self.name, {"payment_je": je.name, "amount": self.user_receives}
 		)
-		frappe.msgprint(f"Payment Journal Entry {je.name} created.")

--- a/admin_panel/admin_panel/page/account_hub/account_hub.js
+++ b/admin_panel/admin_panel/page/account_hub/account_hub.js
@@ -90,6 +90,14 @@ function getLevelLabel(level) {
 	return ACCOUNT_LEVEL_LABELS[level] || level;
 }
 
+const RESULT_STATUS_TONE = {
+	[ACCOUNT_STATUSES.ACTIVE]: "ok",
+	[ACCOUNT_STATUSES.NEW]: "warn",
+	[ACCOUNT_STATUSES.PENDING]: "warn",
+	[ACCOUNT_STATUSES.LOCKED]: "bad",
+	[ACCOUNT_STATUSES.CLOSED]: "off",
+};
+
 function getLevelBadge(level) {
 	return ACCOUNT_LEVEL_BADGES[level] || "badge-trial";
 }
@@ -115,6 +123,12 @@ function formatDate(ts) {
 		" " +
 		d.toLocaleTimeString()
 	);
+}
+
+function formatDateOnly(ts) {
+	if (!ts) return "-";
+	const d = new Date(ts * 1000);
+	return frappe.datetime.global_date_format(d.toISOString().split("T")[0]);
 }
 
 function formatCurrency(cents, currency) {
@@ -210,7 +224,7 @@ class AccountHub {
                 .ah-result-item:hover { background: var(--ah-line-soft); }
                 .ah-result-item.active { background: var(--ah-accent-soft);
                     border-left-color: var(--ah-accent); }
-                .ah-result-avatar { width: 34px; height: 34px; border-radius: 50%;
+                .ah-result-avatar { position: relative; width: 34px; height: 34px; border-radius: 50%;
                     background: var(--ah-accent-soft); color: var(--ah-accent-ink);
                     display: grid; place-items: center; font-weight: 700; font-size: 14px; flex: none; }
                 .ah-result-info { min-width: 0; flex: 1; }
@@ -224,6 +238,12 @@ class AccountHub {
                     border-top-color: var(--ah-accent); border-radius: 50%;
                     margin: 0 auto 8px; animation: ah-spin 0.8s linear infinite; }
                 @keyframes ah-spin { to { transform: rotate(360deg); } }
+                .ah-dot { position: absolute; right: -1px; bottom: -1px; width: 9px; height: 9px;
+                    border-radius: 50%; box-shadow: 0 0 0 2px var(--ah-surface); }
+                .ah-dot-ok { background: var(--ah-good); }
+                .ah-dot-warn { background: var(--ah-warn); }
+                .ah-dot-bad { background: var(--ah-serious); }
+                .ah-dot-off { background: var(--ah-ink3); }
                 .ah-error-msg { margin: 12px 16px; padding: 10px 14px; border-radius: 10px;
                     background: var(--ah-serious-bg); color: var(--ah-serious);
                     font-size: 12.5px; font-weight: 600; }
@@ -236,10 +256,22 @@ class AccountHub {
                     margin-top: 4px; max-width: 340px; margin-left: auto; margin-right: auto; }
                 .ah-right-empty { padding: 90px 20px; }
 
-                /* identity band */
-                .detail-account-title { padding: 16px 20px; font-size: 18px; font-weight: 650;
-                    letter-spacing: -0.01em; }
-                .detail-account-title .fa-user { display: none; }
+                /* identity band — who + what they hold, above the tabs */
+                .ah-ident { padding: 14px 20px 13px; border-bottom: 1px solid var(--ah-line); }
+                .ah-ident-top { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+                .ah-ident-name { font-size: 18px; font-weight: 650; letter-spacing: -0.01em; }
+                .ah-ident-actions { margin-left: auto; display: flex; gap: 8px; flex-wrap: wrap; }
+                .ah-ident-meta { color: var(--ah-ink2); font-size: 12.5px; margin-top: 4px;
+                    display: flex; gap: 7px; align-items: center; flex-wrap: wrap; }
+                .ah-ident-dot { color: var(--ah-ink3); }
+                .ah-ident-balances { display: flex; gap: 8px; margin-top: 11px; flex-wrap: wrap; }
+                .ah-bal-chip { display: inline-flex; align-items: baseline; gap: 7px;
+                    border: 1px solid var(--ah-line); border-radius: 10px; padding: 5px 12px;
+                    background: var(--ah-surface); }
+                .ah-bal-cur { font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase;
+                    color: var(--ah-ink2); font-weight: 650; }
+                .ah-bal-amt { font-size: 15px; font-weight: 650; color: var(--ah-ink);
+                    font-variant-numeric: tabular-nums; }
 
                 /* tabs — underline style */
                 .ah-tabs { display: flex; gap: 2px; padding: 0 14px; border-bottom: 1px solid var(--ah-line);
@@ -270,10 +302,7 @@ class AccountHub {
                 .ah-info-value { font-size: 13px; font-weight: 600; color: var(--ah-ink);
                     text-align: right; word-break: break-word; min-width: 0; }
 
-                /* actions — destructive isolated right */
-                .ah-action-bar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
-                    padding-top: 4px; }
-                .ah-action-bar .btn-lock-account, .ah-action-bar .ah-btn-danger { margin-left: auto; }
+
                 .ah-btn { border: 1px solid var(--ah-line); background: var(--ah-surface);
                     color: var(--ah-ink); border-radius: 9px; padding: 7px 14px; font-size: 13px;
                     font-weight: 600; cursor: pointer; transition: all 0.13s; }
@@ -395,11 +424,28 @@ class AccountHub {
 
                             <!-- Detail Content (shown when account is selected) -->
                             <div class="ah-detail-content" style="display:none;">
-                                <div class="ah-card-header detail-account-title" style="display:flex;align-items:center;gap:10px;">
-                                    <i class="fa fa-user"></i>
-                                    <span class="detail-username-display"></span>
-                                    <span class="ah-badge detail-level-badge" style="margin-left:auto;"></span>
-                                    <span class="ah-badge detail-status-badge"></span>
+                                <div class="ah-ident">
+                                    <div class="ah-ident-top">
+                                        <span class="detail-username-display ah-ident-name"></span>
+                                        <span class="ah-badge detail-level-badge"></span>
+                                        <span class="ah-badge detail-status-badge"></span>
+                                        <div class="ah-ident-actions">
+                                            <button class="ah-btn ah-btn-sm ah-btn-primary btn-change-level">
+                                                <i class="fa fa-level-up"></i> Change Level
+                                            </button>
+                                            <button class="ah-btn ah-btn-sm ah-btn-secondary btn-update-phone">
+                                                <i class="fa fa-phone"></i> Update Phone
+                                            </button>
+                                            <button class="ah-btn ah-btn-sm ah-btn-success btn-activate-account" style="display:none;">
+                                                <i class="fa fa-unlock"></i> Activate
+                                            </button>
+                                            <button class="ah-btn ah-btn-sm ah-btn-danger btn-lock-account" style="display:none;">
+                                                <i class="fa fa-lock"></i> Lock
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="ah-ident-meta detail-ident-meta"></div>
+                                    <div class="ah-ident-balances detail-ident-balances"></div>
                                 </div>
 
                                 <!-- Tabs -->
@@ -456,24 +502,6 @@ class AccountHub {
                                             </div>
                                         </div>
                                     </div>
-
-                                    <!-- Action Bar -->
-                                    <div class="ah-action-bar">
-                                        <div class="btn-group">
-                                            <button class="ah-btn ah-btn-primary btn-change-level">
-                                                <i class="fa fa-level-up"></i> Change Level
-                                            </button>
-                                        </div>
-                                        <button class="ah-btn ah-btn-danger btn-lock-account" style="display:none;">
-                                            <i class="fa fa-lock"></i> Lock Account
-                                        </button>
-                                        <button class="ah-btn ah-btn-success btn-activate-account" style="display:none;">
-                                            <i class="fa fa-unlock"></i> Activate Account
-                                        </button>
-                                        <button class="ah-btn ah-btn-secondary btn-update-phone">
-                                            <i class="fa fa-phone"></i> Update Phone
-                                        </button>
-                                    </div>
                                 </div>
 
                                 <!-- Tab: Wallets -->
@@ -517,6 +545,8 @@ class AccountHub {
 			detailUsername: main.find(".detail-username-display"),
 			detailLevelBadge: main.find(".detail-level-badge"),
 			detailStatusBadge: main.find(".detail-status-badge"),
+			identMeta: main.find(".detail-ident-meta"),
+			identBalances: main.find(".detail-ident-balances"),
 			tabs: main.find(".ah-tab"),
 			tabContents: main.find(".ah-tab-content"),
 			// Overview
@@ -639,6 +669,8 @@ class AccountHub {
 			const initial = (displayName || "?")[0].toUpperCase();
 			const levelLabel = getLevelLabel(level);
 			const levelBadge = getLevelBadge(level);
+			const tone = RESULT_STATUS_TONE[account.status];
+			const dotHtml = tone ? `<span class="ah-dot ah-dot-${tone}"></span>` : "";
 
 			const item = $(`
                 <div class="ah-result-item" data-id="${frappe.utils.escape_html(
@@ -648,7 +680,7 @@ class AccountHub {
 			)}" data-phone="${frappe.utils.escape_html(
 				account.phone_number || ""
 			)}" data-email="${frappe.utils.escape_html(account.email || "")}">
-                    <div class="ah-result-avatar">${initial}</div>
+                    <div class="ah-result-avatar">${initial}${dotHtml}</div>
                     <div class="ah-result-info">
                         <div class="ah-result-name">${frappe.utils.escape_html(displayName)}</div>
                         <div class="ah-result-sub">${frappe.utils.escape_html(subInfo)}</div>
@@ -882,6 +914,37 @@ class AccountHub {
 		this.$.detailStatusBadge
 			.text(getStatusLabel(account.status))
 			.attr("class", "ah-badge " + getStatusBadge(account.status));
+
+		// Identity band: who they are + what they hold, zero clicks in
+		const metaBits = [];
+		if (account.owner?.phone) metaBits.push(formatPhone(account.owner.phone));
+		if (account.owner?.email?.address) metaBits.push(account.owner.email.address);
+		if (account.createdAt) metaBits.push("Joined " + formatDateOnly(account.createdAt));
+		this.$.identMeta.html(
+			metaBits
+				.map((bit) => `<span>${frappe.utils.escape_html(bit)}</span>`)
+				.join('<span class="ah-ident-dot">\u00b7</span>')
+		);
+		this.$.identMeta.toggle(metaBits.length > 0);
+		const balanceWallets = [...(account.wallets || [])].sort((a, b) => {
+			if (a.walletCurrency === "USD") return -1;
+			if (b.walletCurrency === "USD") return 1;
+			return 0;
+		});
+		this.$.identBalances.html(
+			balanceWallets
+				.map(
+					(w) =>
+						`<span class="ah-bal-chip"><span class="ah-bal-cur">${frappe.utils.escape_html(
+							w.walletCurrency || "USD"
+						)}</span><span class="ah-bal-amt">${formatCurrency(
+							w.balance,
+							w.walletCurrency
+						)}</span></span>`
+				)
+				.join("")
+		);
+		this.$.identBalances.toggle(balanceWallets.length > 0);
 
 		// Activate first tab
 		this.$.tabs.removeClass("active");

--- a/admin_panel/admin_panel/page/account_hub/account_hub.js
+++ b/admin_panel/admin_panel/page/account_hub/account_hub.js
@@ -91,12 +91,22 @@ function getLevelLabel(level) {
 }
 
 const RESULT_STATUS_TONE = {
+	// account statuses (UPPERCASE) — account search results
 	[ACCOUNT_STATUSES.ACTIVE]: "ok",
 	[ACCOUNT_STATUSES.NEW]: "warn",
 	[ACCOUNT_STATUSES.PENDING]: "warn",
 	[ACCOUNT_STATUSES.LOCKED]: "bad",
 	[ACCOUNT_STATUSES.CLOSED]: "off",
+	// upgrade-request statuses arrive Title Case from the doctype; the
+	// lookup uppercases, so only the two extra vocabulary words go here
+	APPROVED: "ok",
+	REJECTED: "bad",
 };
+
+function statusDotHtml(status) {
+	const tone = RESULT_STATUS_TONE[String(status || "").toUpperCase()];
+	return tone ? `<span class="ah-dot ah-dot-${tone}"></span>` : "";
+}
 
 function getLevelBadge(level) {
 	return ACCOUNT_LEVEL_BADGES[level] || "badge-trial";
@@ -191,7 +201,7 @@ class AccountHub {
                 /* layout */
                 .ah-container { display: flex; gap: 16px; align-items: flex-start; }
                 .ah-left-panel { width: 320px; min-width: 280px; flex-shrink: 0;
-                    position: sticky; top: 12px; }
+                    position: sticky; top: calc(var(--navbar-height, 60px) + 12px); }
                 .ah-right-panel { flex: 1; min-width: 0; }
                 @media (max-width: 900px) {
                     .ah-container { flex-direction: column; }
@@ -669,8 +679,7 @@ class AccountHub {
 			const initial = (displayName || "?")[0].toUpperCase();
 			const levelLabel = getLevelLabel(level);
 			const levelBadge = getLevelBadge(level);
-			const tone = RESULT_STATUS_TONE[account.status];
-			const dotHtml = tone ? `<span class="ah-dot ah-dot-${tone}"></span>` : "";
+			const dotHtml = statusDotHtml(account.status);
 
 			const item = $(`
                 <div class="ah-result-item" data-id="${frappe.utils.escape_html(
@@ -876,7 +885,7 @@ class AccountHub {
 
 		const item = $(`
             <div class="ah-result-item" data-uuid="${account.uuid}">
-                <div class="ah-result-avatar">${initial}</div>
+                <div class="ah-result-avatar">${initial}${statusDotHtml(account.status)}</div>
                 <div class="ah-result-info">
                     <div class="ah-result-name">${frappe.utils.escape_html(
 						account.username || "Unknown"

--- a/admin_panel/admin_panel/page/account_hub/account_hub.js
+++ b/admin_panel/admin_panel/page/account_hub/account_hub.js
@@ -148,554 +148,202 @@ class AccountHub {
 	create_layout() {
 		this.page.main.html(`
             <style>
+                /* ═══ Ops-pulse design system — Account Hub (customer workbench) ═══
+                   Same tokens as the dashboard/census; legacy --color-* names are
+                   aliased so dynamic templates restyle without markup changes. */
                 .account-hub {
-                    --color-primary: #007856;
-                    --color-background: #F1F1F1;
-                    --color-layer: #FFFFFF;
-                    --color-text01: #212121;
-                    --color-text02: #939998;
-                    --color-border01: #DDE3E1;
-                    --color-green: #00A700;
-                    --color-error: #DC2626;
-                    --color-warning: #F59E0B;
-                }
-
-                .account-hub {
-                    max-width: 1600px;
-                    margin: 0 auto;
-                }
-
-                /* ── Layout ── */
-                .ah-container {
-                    display: flex;
-                    gap: 24px;
-                    align-items: flex-start;
-                }
-
-                .ah-left-panel {
-                    width: 30%;
-                    min-width: 300px;
-                    flex-shrink: 0;
-                }
-
-                .ah-right-panel {
-                    flex: 1;
-                    min-width: 0;
-                }
-
-                /* ── Cards ── */
-                .ah-card {
-                    background: var(--color-layer);
-                    border-radius: 16px;
-                    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
-                    border: 1px solid var(--color-border01);
-                    overflow: hidden;
-                }
-
-                .ah-card-header {
-                    padding: 16px 20px;
-                    background: linear-gradient(135deg, var(--color-primary) 0%, #005a42 100%);
-                    color: white;
-                    font-size: 16px;
-                    font-weight: 600;
-                }
-
-                .ah-card-body {
-                    padding: 20px;
-                }
-
-                /* ── Search ── */
-                .ah-search-wrapper {
-                    padding: 20px;
-                }
-
-                .ah-search-input {
-                    width: 100%;
-                    padding: 12px 16px;
-                    border: 2px solid var(--color-border01);
-                    border-radius: 12px;
-                    font-size: 15px;
-                    transition: all 0.2s ease;
-                    background: var(--color-layer);
-                    color: var(--color-text01);
-                    box-sizing: border-box;
-                }
-
-                .ah-search-input:focus {
-                    outline: none;
-                    border-color: var(--color-primary);
-                    box-shadow: 0 0 0 3px rgba(0,120,86,0.1);
-                }
-
-                .ah-search-input::placeholder {
-                    color: var(--color-text02);
-                }
-
-                /* ── Search Results Area ── */
-                .ah-results-area {
-                    border-top: 1px solid var(--color-border01);
-                    min-height: 100px;
-                }
-
-                .ah-result-item {
-                    padding: 14px 20px;
-                    cursor: pointer;
-                    transition: background 0.15s;
-                    border-bottom: 1px solid var(--color-border01);
-                    display: flex;
-                    align-items: center;
-                    gap: 12px;
-                }
-
-                .ah-result-item:last-child {
-                    border-bottom: none;
-                }
-
-                .ah-result-item:hover {
-                    background: rgba(0,120,86,0.03);
-                }
-
-                .ah-result-item.active {
-                    background: rgba(0,120,86,0.1);
-                    border-left: 4px solid var(--color-primary);
-                }
-
-                .ah-result-avatar {
-                    width: 40px;
-                    height: 40px;
-                    border-radius: 50%;
-                    background: var(--color-primary);
-                    color: white;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    font-weight: 600;
-                    font-size: 16px;
-                    flex-shrink: 0;
-                }
-
-                .ah-result-info {
-                    flex: 1;
-                    min-width: 0;
-                }
-
-                .ah-result-name {
-                    font-weight: 600;
-                    color: var(--color-text01);
-                    font-size: 14px;
-                }
-
-                .ah-result-sub {
-                    font-size: 12px;
-                    color: var(--color-text02);
-                    margin-top: 2px;
-                }
-
-                /* ── Tabs ── */
-                .ah-tabs {
-                    display: flex;
-                    border-bottom: 2px solid var(--color-border01);
-                    background: var(--color-layer);
-                    padding: 0 4px;
-                }
-
-                .ah-tab {
-                    padding: 14px 20px;
-                    cursor: pointer;
-                    font-size: 14px;
-                    font-weight: 500;
-                    color: var(--color-text02);
-                    border-bottom: 2px solid transparent;
-                    margin-bottom: -2px;
-                    transition: all 0.2s;
-                    background: none;
-                    border-top: none;
-                    border-left: none;
-                    border-right: none;
-                }
-
-                .ah-tab:hover {
-                    color: var(--color-primary);
-                    background: rgba(0,120,86,0.03);
-                }
-
-                .ah-tab.active {
-                    color: var(--color-primary);
-                    border-bottom-color: var(--color-primary);
-                }
-
-                .ah-tab-content {
-                    display: none;
-                    padding: 24px;
-                }
-
-                .ah-tab-content.active {
-                    display: block;
-                }
-
-                /* ── Info Cards ── */
-                .ah-info-grid {
-                    display: grid;
-                    grid-template-columns: 1fr 1fr;
-                    gap: 24px;
-                    margin-bottom: 20px;
-                }
-
-                .ah-info-card {
-                    background: var(--color-layer);
-                    border: 1px solid var(--color-border01);
-                    border-radius: 12px;
-                    padding: 20px;
-                }
-
-                .ah-info-card h6 {
-                    font-size: 13px;
-                    font-weight: 600;
-                    color: var(--color-text02);
-                    text-transform: uppercase;
-                    letter-spacing: 0.5px;
-                    margin: 0 0 16px 0;
-                    padding-bottom: 10px;
-                    border-bottom: 1px solid var(--color-border01);
-                }
-
-                .ah-info-row {
-                    display: flex;
-                    justify-content: space-between;
-                    padding: 6px 0;
-                    font-size: 14px;
-                }
-
-                .ah-info-label {
-                    color: var(--color-text02);
-                }
-
-                .ah-info-value {
-                    color: var(--color-text01);
-                    font-weight: 500;
-                    text-align: right;
-                }
-
-                .ah-verified-badge {
-                    background: rgba(0,167,0,0.1);
-                    color: var(--color-green);
-                    padding: 2px 8px;
-                    border-radius: 10px;
-                    font-size: 11px;
-                    font-weight: 600;
-                    margin-left: 6px;
-                }
-
-                /* ── Badges ── */
-                .ah-badge {
-                    display: inline-flex;
-                    align-items: center;
-                    padding: 4px 10px;
-                    border-radius: 20px;
-                    font-size: 11px;
-                    font-weight: 600;
-                    text-transform: uppercase;
-                    letter-spacing: 0.5px;
-                }
-
-                .ah-badge.badge-trial {
-                    background: rgba(148,163,159,0.15);
-                    color: var(--color-text02);
-                }
-                .ah-badge.badge-personal {
-                    background: rgba(0,120,86,0.1);
-                    color: var(--color-primary);
-                }
-                .ah-badge.badge-business {
-                    background: rgba(232,211,21,0.15);
-                    color: #b8a00e;
-                }
-                .ah-badge.badge-merchant {
-                    background: rgba(245,158,11,0.15);
-                    color: var(--color-warning);
-                }
-                .ah-badge.badge-pending {
-                    background: rgba(245,158,11,0.15);
-                    color: var(--color-warning);
-                }
-                .ah-badge.badge-approved {
-                    background: #d4f7d9;
-                    color: #15803d;
-                }
-                .ah-badge.badge-rejected {
-                    background: #fde2e2;
-                    color: #b91c1c;
-                }
-                .ah-badge.badge-closed {
-                    background: rgba(100,116,139,0.15);
-                    color: #475569;
-                }
-
-                /* ── Action Toolbar ── */
-                .ah-action-bar {
-                    display: flex;
-                    gap: 10px;
-                    flex-wrap: wrap;
-                    padding-top: 20px;
-                    border-top: 1px solid var(--color-border01);
-                    margin-top: 20px;
-                }
-
-                .ah-btn {
-                    padding: 10px 18px;
-                    border-radius: 10px;
-                    font-weight: 500;
-                    font-size: 14px;
-                    border: none;
-                    cursor: pointer;
-                    transition: all 0.2s ease;
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 6px;
-                }
-
-                .ah-btn-primary {
-                    background: var(--color-primary);
-                    color: white;
-                }
-                .ah-btn-primary:hover {
-                    background: #005a42;
-                    transform: translateY(-1px);
-                    box-shadow: 0 4px 12px rgba(0,120,86,0.2);
-                }
-
-                .ah-btn-success {
-                    background: var(--color-green);
-                    color: white;
-                }
-                .ah-btn-success:hover {
-                    background: #008f00;
-                }
-
-                .ah-btn-danger {
-                    background: var(--color-error);
-                    color: white;
-                }
-                .ah-btn-danger:hover {
-                    background: #b91c1c;
-                }
-
-                .ah-btn-secondary {
-                    background: var(--color-layer);
-                    color: var(--color-text01);
-                    border: 2px solid var(--color-border01);
-                }
-                .ah-btn-secondary:hover {
-                    background: var(--color-background);
-                    border-color: var(--color-text02);
-                }
-
-                .ah-btn-sm {
-                    padding: 6px 12px;
-                    font-size: 12px;
-                    border-radius: 8px;
-                }
-
-                /* ── Wallet Cards ── */
-                .ah-wallet-card {
-                    background: var(--color-layer);
-                    border: 1px solid var(--color-border01);
-                    border-radius: 12px;
-                    padding: 20px;
-                    margin-bottom: 16px;
-                }
-
-                .ah-wallet-row {
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                    padding: 6px 0;
-                    font-size: 14px;
-                }
-
-                .ah-wallet-balance {
-                    font-size: 28px;
-                    font-weight: 700;
-                    color: var(--color-text01);
-                }
-
-                .ah-wallet-currency-badge {
-                    display: inline-flex;
-                    align-items: center;
-                    padding: 4px 12px;
-                    border-radius: 20px;
-                    font-size: 12px;
-                    font-weight: 600;
-                    background: rgba(0,120,86,0.1);
-                    color: var(--color-primary);
-                }
-
-                /* ── Document Item ── */
-                .ah-doc-item {
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                    padding: 12px 16px;
-                    background: var(--color-background);
-                    border-radius: 10px;
-                    margin-bottom: 8px;
-                    border: 1px solid var(--color-border01);
-                }
-
-                .ah-doc-info {
-                    font-size: 14px;
-                    color: var(--color-text01);
-                }
-
-                /* ── Merchant Card ── */
-                .ah-merchant-card {
-                    background: var(--color-layer);
-                    border: 1px solid var(--color-border01);
-                    border-radius: 12px;
-                    padding: 16px;
-                    margin-bottom: 12px;
-                }
-
-                .ah-merchant-title {
-                    font-size: 16px;
-                    font-weight: 600;
-                    color: var(--color-text01);
-                    margin-bottom: 8px;
-                }
-
-                .ah-merchant-row {
-                    font-size: 13px;
-                    color: var(--color-text02);
-                    padding: 3px 0;
-                }
-
-                .ah-merchant-actions {
-                    margin-top: 12px;
-                    display: flex;
-                    gap: 8px;
-                }
-
-                /* ── Upgrade Table ── */
-                .ah-table {
-                    width: 100%;
-                    border-collapse: separate;
-                    border-spacing: 0;
-                }
-
-                .ah-table thead {
-                    background: var(--color-background);
-                }
-
-                .ah-table th {
-                    padding: 12px 16px;
-                    text-align: left;
-                    font-size: 12px;
-                    font-weight: 600;
-                    color: var(--color-text02);
-                    text-transform: uppercase;
-                    letter-spacing: 0.5px;
-                    border-bottom: 2px solid var(--color-border01);
-                }
-
-                .ah-table td {
-                    padding: 12px 16px;
-                    font-size: 14px;
-                    color: var(--color-text01);
-                    border-bottom: 1px solid var(--color-border01);
-                }
-
-                .ah-table tr:last-child td {
-                    border-bottom: none;
-                }
-
-                /* ── Empty State ── */
-                .ah-empty {
-                    padding: 60px 20px;
-                    text-align: center;
-                    color: var(--color-text02);
-                }
-
-                .ah-empty-icon {
-                    font-size: 40px;
-                    margin-bottom: 12px;
-                    opacity: 0.3;
-                }
-
-                .ah-empty-text {
-                    font-size: 15px;
-                    font-weight: 500;
-                }
-
-                .ah-empty-sub {
-                    font-size: 13px;
-                    margin-top: 4px;
-                }
-
-                /* ── Loading ── */
-                .ah-loading {
-                    padding: 40px 20px;
-                    text-align: center;
-                }
-
-                .ah-spinner {
-                    width: 36px;
-                    height: 36px;
-                    border: 3px solid var(--color-border01);
-                    border-top-color: var(--color-primary);
-                    border-radius: 50%;
-                    animation: ah-spin 0.8s linear infinite;
-                    margin: 0 auto 12px;
-                }
-
-                @keyframes ah-spin {
-                    to { transform: rotate(360deg); }
-                }
-
-                .ah-error-msg {
-                    padding: 16px 20px;
-                    color: var(--color-error);
-                    font-size: 14px;
-                    display: flex;
-                    align-items: center;
-                    gap: 8px;
-                    background: rgba(220,38,38,0.04);
-                    border-top: 1px solid rgba(220,38,38,0.15);
-                }
-
-                /* ── Right Panel Hidden State ── */
-                .ah-right-empty {
-                    padding: 80px 20px;
-                    text-align: center;
-                    color: var(--color-text02);
-                }
-
-                .ah-right-empty-icon {
-                    font-size: 56px;
-                    margin-bottom: 16px;
-                    opacity: 0.2;
-                }
-
-                .ah-right-empty-text {
-                    font-size: 18px;
-                    font-weight: 500;
-                }
-
-                .ah-right-empty-sub {
-                    font-size: 14px;
-                    margin-top: 4px;
-                }
-
+                    --ah-surface: var(--card-bg, #ffffff); --ah-ink: var(--text-color, #1a2420);
+                    --ah-ink2: var(--text-muted, #5c6b65); --ah-ink3: var(--text-light, #8fa098);
+                    --ah-line: var(--border-color, #e2e8e5); --ah-line-soft: var(--subtle-fg, #ecf1ee);
+                    --ah-accent: #007856; --ah-accent-ink: #007856; --ah-accent-soft: #e6f3ee;
+                    --ah-good: #0ca30c; --ah-warn: #b87d00; --ah-warn-bg: #fff3d6;
+                    --ah-serious: #c05a32; --ah-serious-bg: #fdeae2;
+                    --ah-shadow: 0 1px 2px rgba(26,36,32,0.05), 0 4px 14px rgba(26,36,32,0.04);
+                    /* legacy aliases (dynamic templates reference these inline) */
+                    --color-primary: var(--ah-accent); --color-background: transparent;
+                    --color-layer: var(--ah-surface); --color-text01: var(--ah-ink);
+                    --color-text02: var(--ah-ink2); --color-border01: var(--ah-line);
+                    --color-green: var(--ah-good); --color-error: var(--ah-serious);
+                    --color-warning: var(--ah-warn);
+                    max-width: 1400px; margin: 0 auto;
+                }
+                [data-theme="dark"] .account-hub, .dark .account-hub {
+                    --ah-accent: #1e9e75; --ah-accent-ink: #4cc29e; --ah-accent-soft: #12352a;
+                    --ah-good: #35c135; --ah-warn: #fab219; --ah-warn-bg: #33290d;
+                    --ah-serious: #ec835a; --ah-serious-bg: #38211a;
+                    --ah-shadow: 0 1px 2px rgba(0,0,0,0.35), 0 6px 18px rgba(0,0,0,0.25);
+                }
+
+                /* layout */
+                .ah-container { display: flex; gap: 16px; align-items: flex-start; }
+                .ah-left-panel { width: 320px; min-width: 280px; flex-shrink: 0;
+                    position: sticky; top: 12px; }
+                .ah-right-panel { flex: 1; min-width: 0; }
                 @media (max-width: 900px) {
-                    .ah-container {
-                        flex-direction: column;
-                    }
-                    .ah-left-panel {
-                        width: 100%;
-                        min-width: 0;
-                    }
-                    .ah-info-grid {
-                        grid-template-columns: 1fr;
-                    }
+                    .ah-container { flex-direction: column; }
+                    .ah-left-panel { width: 100%; position: static; }
+                }
+
+                .ah-card { background: var(--ah-surface); border: 1px solid var(--ah-line);
+                    border-radius: 14px; box-shadow: var(--ah-shadow); overflow: hidden; }
+                .ah-card-header { padding: 13px 18px; border-bottom: 1px solid var(--ah-line);
+                    font-size: 13.5px; font-weight: 650; color: var(--ah-ink);
+                    display: flex; align-items: center; }
+                .ah-card-header .fa { color: var(--ah-accent-ink); }
+
+                /* search rail */
+                .ah-search-wrapper { padding: 14px 16px 10px; }
+                .ah-search-input { width: 100%; padding: 9px 13px; border: 1px solid var(--ah-line);
+                    border-radius: 10px; font-size: 13.5px; background: var(--ah-surface);
+                    color: var(--ah-ink); box-sizing: border-box; transition: border-color 0.15s; }
+                .ah-search-input:focus { outline: 2px solid var(--ah-accent); outline-offset: 1px;
+                    border-color: var(--ah-accent); }
+                .ah-search-input::placeholder { color: var(--ah-ink3); }
+                .ah-search-hint { padding: 0 2px; }
+                .ah-results-area { border-top: 1px solid var(--ah-line-soft); min-height: 90px;
+                    max-height: calc(100vh - 260px); overflow-y: auto; }
+
+                .ah-result-item { display: flex; align-items: center; gap: 11px;
+                    padding: 11px 16px; cursor: pointer; border-left: 3px solid transparent;
+                    border-bottom: 1px solid var(--ah-line-soft); transition: background 0.12s; }
+                .ah-result-item:last-child { border-bottom: none; }
+                .ah-result-item:hover { background: var(--ah-line-soft); }
+                .ah-result-item.active { background: var(--ah-accent-soft);
+                    border-left-color: var(--ah-accent); }
+                .ah-result-avatar { width: 34px; height: 34px; border-radius: 50%;
+                    background: var(--ah-accent-soft); color: var(--ah-accent-ink);
+                    display: grid; place-items: center; font-weight: 700; font-size: 14px; flex: none; }
+                .ah-result-info { min-width: 0; flex: 1; }
+                .ah-result-name { font-weight: 600; font-size: 13px; color: var(--ah-ink);
+                    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+                .ah-result-sub { color: var(--ah-ink2); font-size: 11.5px;
+                    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+                .ah-loading { text-align: center; padding: 26px 0; }
+                .ah-spinner { width: 22px; height: 22px; border: 2px solid var(--ah-line);
+                    border-top-color: var(--ah-accent); border-radius: 50%;
+                    margin: 0 auto 8px; animation: ah-spin 0.8s linear infinite; }
+                @keyframes ah-spin { to { transform: rotate(360deg); } }
+                .ah-error-msg { margin: 12px 16px; padding: 10px 14px; border-radius: 10px;
+                    background: var(--ah-serious-bg); color: var(--ah-serious);
+                    font-size: 12.5px; font-weight: 600; }
+                .ah-empty, .ah-right-empty { text-align: center; padding: 34px 20px; }
+                .ah-empty-icon, .ah-right-empty-icon { font-size: 26px; margin-bottom: 8px;
+                    filter: grayscale(0.4); opacity: 0.75; }
+                .ah-empty-text, .ah-right-empty-text { font-weight: 650; font-size: 13.5px;
+                    color: var(--ah-ink); }
+                .ah-empty-sub, .ah-right-empty-sub { color: var(--ah-ink3); font-size: 12px;
+                    margin-top: 4px; max-width: 340px; margin-left: auto; margin-right: auto; }
+                .ah-right-empty { padding: 90px 20px; }
+
+                /* identity band */
+                .detail-account-title { padding: 16px 20px; font-size: 18px; font-weight: 650;
+                    letter-spacing: -0.01em; }
+                .detail-account-title .fa-user { display: none; }
+
+                /* tabs — underline style */
+                .ah-tabs { display: flex; gap: 2px; padding: 0 14px; border-bottom: 1px solid var(--ah-line);
+                    overflow-x: auto; }
+                .ah-tab { border: none; background: transparent; color: var(--ah-ink2);
+                    font-size: 12.5px; font-weight: 600; padding: 10px 12px 9px; cursor: pointer;
+                    border-bottom: 2px solid transparent; margin-bottom: -1px; white-space: nowrap;
+                    transition: color 0.12s; }
+                .ah-tab:hover { color: var(--ah-ink); }
+                .ah-tab.active { color: var(--ah-accent-ink); border-bottom-color: var(--ah-accent); }
+                .ah-tab:focus-visible { outline: 2px solid var(--ah-accent); outline-offset: -2px; }
+                .ah-tab-content { display: none; padding: 18px 20px 20px; }
+                .ah-tab-content.active { display: block; }
+
+                /* overview kv cards */
+                .ah-info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+                    gap: 12px; margin-bottom: 16px; }
+                .ah-info-card { background: var(--ah-surface); border: 1px solid var(--ah-line);
+                    border-radius: 12px; padding: 14px 16px; }
+                .ah-info-card h6 { font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase;
+                    color: var(--ah-ink2); font-weight: 650; margin: 0 0 10px; }
+                .ah-info-card h6 .fa { display: none; }
+                .ah-info-row { display: flex; justify-content: space-between; gap: 12px;
+                    padding: 5px 0; align-items: baseline; }
+                .ah-info-row + .ah-info-row { border-top: 1px solid var(--ah-line-soft); }
+                .ah-info-label { font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase;
+                    color: var(--ah-ink2); font-weight: 600; flex: none; }
+                .ah-info-value { font-size: 13px; font-weight: 600; color: var(--ah-ink);
+                    text-align: right; word-break: break-word; min-width: 0; }
+
+                /* actions — destructive isolated right */
+                .ah-action-bar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+                    padding-top: 4px; }
+                .ah-action-bar .btn-lock-account, .ah-action-bar .ah-btn-danger { margin-left: auto; }
+                .ah-btn { border: 1px solid var(--ah-line); background: var(--ah-surface);
+                    color: var(--ah-ink); border-radius: 9px; padding: 7px 14px; font-size: 13px;
+                    font-weight: 600; cursor: pointer; transition: all 0.13s; }
+                .ah-btn:hover { border-color: var(--ah-accent); }
+                .ah-btn:focus-visible { outline: 2px solid var(--ah-accent); outline-offset: 1px; }
+                .ah-btn .fa { margin-right: 5px; }
+                .ah-btn-primary { background: var(--ah-accent); border-color: var(--ah-accent); color: #fff; }
+                .ah-btn-primary:hover { filter: brightness(1.07); }
+                .ah-btn-secondary { background: var(--ah-surface); }
+                .ah-btn-success { color: var(--ah-good); border-color: var(--ah-good); background: transparent; }
+                .ah-btn-success:hover { background: var(--ah-accent-soft); }
+                .ah-btn-danger { color: var(--ah-serious); border-color: var(--ah-serious); background: transparent; }
+                .ah-btn-danger:hover { background: var(--ah-serious-bg); border-color: var(--ah-serious); }
+                .ah-btn-sm { padding: 4px 10px; font-size: 12px; }
+                .ah-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+                /* chips — level tiers express intensity of one accent; status is semantic */
+                .ah-badge { display: inline-flex; align-items: center; border-radius: 999px;
+                    padding: 3px 11px; font-size: 11.5px; font-weight: 650; letter-spacing: 0.02em;
+                    background: var(--ah-line-soft); color: var(--ah-ink2); }
+                .badge-trial { background: var(--ah-line-soft); color: var(--ah-ink2); }
+                .badge-personal { background: var(--ah-accent-soft); color: var(--ah-accent-ink); opacity: 0.85; }
+                .badge-business { background: var(--ah-accent-soft); color: var(--ah-accent-ink); }
+                .badge-merchant { background: var(--ah-accent); color: #fff; }
+                .badge-pending { background: var(--ah-warn-bg); color: var(--ah-warn); }
+                .badge-approved { background: var(--ah-accent-soft); color: var(--ah-accent-ink); }
+                .badge-rejected { background: var(--ah-serious-bg); color: var(--ah-serious); }
+                .badge-closed { background: var(--ah-line-soft); color: var(--ah-ink3); }
+                .ah-verified-badge { display: inline-flex; align-items: center; border-radius: 999px;
+                    padding: 2px 9px; font-size: 11px; font-weight: 650;
+                    background: var(--ah-accent-soft); color: var(--ah-accent-ink); margin-left: 6px; }
+
+                /* wallets */
+                .ah-wallet-card { background: var(--ah-surface); border: 1px solid var(--ah-line);
+                    border-radius: 12px; padding: 14px 16px; margin-bottom: 12px; }
+                .ah-wallet-currency-badge { display: inline-flex; border-radius: 999px;
+                    padding: 3px 11px; font-size: 11.5px; font-weight: 650;
+                    background: var(--ah-accent-soft); color: var(--ah-accent-ink); }
+                .ah-wallet-balance { font-size: 20px; font-weight: 650; color: var(--ah-ink);
+                    font-variant-numeric: tabular-nums; }
+                .ah-wallet-row { display: flex; justify-content: space-between; gap: 12px;
+                    padding: 4px 0; align-items: baseline; }
+
+                /* documents */
+                .ah-doc-item { display: flex; align-items: center; justify-content: space-between;
+                    gap: 12px; background: var(--ah-surface); border: 1px solid var(--ah-line);
+                    border-radius: 12px; padding: 12px 16px; margin-bottom: 10px; }
+                .ah-doc-info { min-width: 0; flex: 1; font-size: 13px; color: var(--ah-ink); }
+
+                /* merchant */
+                .ah-merchant-card { background: var(--ah-surface); border: 1px solid var(--ah-line);
+                    border-radius: 12px; padding: 14px 16px; margin-bottom: 12px; }
+                .ah-merchant-title { font-weight: 650; font-size: 14px; color: var(--ah-ink);
+                    margin-bottom: 8px; }
+                .ah-merchant-row { display: flex; justify-content: space-between; gap: 12px;
+                    padding: 4px 0; font-size: 13px; align-items: baseline; }
+                .ah-merchant-actions { display: flex; gap: 8px; margin-top: 10px; }
+
+                /* upgrade history table */
+                .ah-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+                .ah-table th { text-align: left; font-size: 11px; letter-spacing: 0.05em;
+                    text-transform: uppercase; color: var(--ah-ink2); font-weight: 650;
+                    padding: 9px 12px; border-bottom: 1px solid var(--ah-line); }
+                .ah-table td { padding: 9px 12px; border-bottom: 1px solid var(--ah-line-soft);
+                    color: var(--ah-ink); font-variant-numeric: tabular-nums; }
+                .ah-table tr:last-child td { border-bottom: none; }
+
+                @media (prefers-reduced-motion: no-preference) {
+                    .ah-detail-content, .ah-result-item { animation: ah-rise 0.3s ease; }
+                    @keyframes ah-rise { from { opacity: 0; transform: translateY(5px); } }
                 }
             </style>
 

--- a/admin_panel/admin_panel/page/account_management/account_management.js
+++ b/admin_panel/admin_panel/page/account_management/account_management.js
@@ -17,7 +17,7 @@ frappe.pages["account-management"].on_page_load = function (wrapper) {
 		return;
 	}
 
-	var page = frappe.ui.make_app_page({
+	page = frappe.ui.make_app_page({
 		parent: wrapper,
 		title: "Flash Account Manager",
 		single_column: true,
@@ -323,10 +323,10 @@ class FlashAccountManager {
                 <!-- Search Bar -->
                 <div class="modern-search-card">
                     <div class="modern-search-wrapper" style="margin-bottom:20px;">
-                        <input 
-                            type="text" 
-                            id="search-input" 
-                            class="modern-search-input search-input" 
+                        <input
+                            type="text"
+                            id="search-input"
+                            class="modern-search-input search-input"
                             placeholder="Enter username or phone number"
                         >
                         <button class="modern-btn modern-btn-primary btn-search">

--- a/admin_panel/admin_panel/page/account_management/account_management.js
+++ b/admin_panel/admin_panel/page/account_management/account_management.js
@@ -699,7 +699,9 @@ class FlashAccountManager {
 		main.find(".btn-refresh").on("click", () => this.load_upgrade_requests());
 
 		$(document).on("keydown.account_management", (e) => {
-			if (e.key === "Escape" && !window.cur_dialog) {
+			// wrapper visibility guard: desk keeps this page alive after
+			// navigation, and this handler must not fire on other pages
+			if (e.key === "Escape" && !window.cur_dialog && this.page.wrapper.is(":visible")) {
 				this.close_details();
 			}
 		});
@@ -777,10 +779,18 @@ class FlashAccountManager {
 		this.load_upgrade_requests();
 	}
 
+	server_now_ms() {
+		// Ages are measured against the server clock the payload ships, not
+		// the browser clock — operator tz must not skew warn/bad tones.
+		const raw = this.pulse && this.pulse.now;
+		const parsed = raw ? new Date(String(raw).replace(" ", "T")).getTime() : NaN;
+		return isNaN(parsed) ? Date.now() : parsed;
+	}
+
 	formatAge(dateStr) {
-		const then = new Date(dateStr);
+		const then = new Date(String(dateStr).replace(" ", "T"));
 		if (isNaN(then)) return "";
-		const mins = Math.max(0, Math.floor((Date.now() - then.getTime()) / 60000));
+		const mins = Math.max(0, Math.floor((this.server_now_ms() - then.getTime()) / 60000));
 		if (mins < 60) return `${mins}m`;
 		const hours = Math.floor(mins / 60);
 		if (hours < 24) return `${hours}h`;
@@ -788,9 +798,9 @@ class FlashAccountManager {
 	}
 
 	age_tone(dateStr) {
-		const then = new Date(dateStr);
+		const then = new Date(String(dateStr).replace(" ", "T"));
 		if (isNaN(then)) return "";
-		const hours = (Date.now() - then.getTime()) / 3600e3;
+		const hours = (this.server_now_ms() - then.getTime()) / 3600e3;
 		if (hours >= 24) return "bad";
 		if (hours >= 6) return "warn";
 		return "";

--- a/admin_panel/admin_panel/page/account_management/account_management.js
+++ b/admin_panel/admin_panel/page/account_management/account_management.js
@@ -1,12 +1,12 @@
-frappe.pages['account-management'].on_page_load = function(wrapper) {
-    if (!frappe.user_roles.includes('Accounts Manager')) {
-        var page = frappe.ui.make_app_page({
-            parent: wrapper,
-            title: 'Flash Account Manager',
-            single_column: true
-        });
-        
-        page.main.html(`
+frappe.pages["account-management"].on_page_load = function (wrapper) {
+	if (!frappe.user_roles.includes("Accounts Manager")) {
+		var page = frappe.ui.make_app_page({
+			parent: wrapper,
+			title: "Flash Account Manager",
+			single_column: true,
+		});
+
+		page.main.html(`
             <div class="text-center mt-5">
                 <div class="alert alert-warning">
                     <h4>Access Denied</h4>
@@ -14,116 +14,116 @@ frappe.pages['account-management'].on_page_load = function(wrapper) {
                 </div>
             </div>
         `);
-        return;
-    }
+		return;
+	}
 
-    var page = frappe.ui.make_app_page({
-        parent: wrapper,
-        title: 'Flash Account Manager',
-        single_column: true
-    });
+	var page = frappe.ui.make_app_page({
+		parent: wrapper,
+		title: "Flash Account Manager",
+		single_column: true,
+	});
 
-    new FlashAccountManager(page);
+	new FlashAccountManager(page);
 };
 
 const AccountLevels = {
-    TRIAL: "ZERO",
-    PERSONAL: "ONE",
-    PRO: "TWO",
-    MERCHANT: "THREE"
+	TRIAL: "ZERO",
+	PERSONAL: "ONE",
+	PRO: "TWO",
+	MERCHANT: "THREE",
 };
 
 const AccountStatus = {
-    PENDING: "Pending",
-    REJECTED: "Rejected",
-    APPROVED: "Approved",
-    CLOSED: "Closed"
+	PENDING: "Pending",
+	REJECTED: "Rejected",
+	APPROVED: "Approved",
+	CLOSED: "Closed",
 };
 
 const ACCOUNT_LEVEL_MAP = {
-    [AccountLevels.TRIAL]: 'Trial',
-    [AccountLevels.PERSONAL]: 'Personal',
-    [AccountLevels.PRO]: 'Pro',
-    [AccountLevels.MERCHANT]: 'Merchant'
+	[AccountLevels.TRIAL]: "Trial",
+	[AccountLevels.PERSONAL]: "Personal",
+	[AccountLevels.PRO]: "Pro",
+	[AccountLevels.MERCHANT]: "Merchant",
 };
 
 const LEVEL_BADGE_MAP = {
-    [AccountLevels.TRIAL]: 'badge-trial',
-    [AccountLevels.PERSONAL]: 'badge-personal',
-    [AccountLevels.PRO]: 'badge-business',
-    [AccountLevels.MERCHANT]: 'badge-merchant'
+	[AccountLevels.TRIAL]: "badge-trial",
+	[AccountLevels.PERSONAL]: "badge-personal",
+	[AccountLevels.PRO]: "badge-business",
+	[AccountLevels.MERCHANT]: "badge-merchant",
 };
 
 const STATUS_BADGE_MAP = {
-    [AccountStatus.APPROVED]: 'badge-approved',
-    [AccountStatus.REJECTED]: 'badge-rejected',
-    [AccountStatus.PENDING]: 'badge-pending',
-    [AccountStatus.CLOSED]: 'badge-closed'
+	[AccountStatus.APPROVED]: "badge-approved",
+	[AccountStatus.REJECTED]: "badge-rejected",
+	[AccountStatus.PENDING]: "badge-pending",
+	[AccountStatus.CLOSED]: "badge-closed",
 };
 
 function getAccountLevelLabel(level) {
-    return ACCOUNT_LEVEL_MAP[level] || level;
+	return ACCOUNT_LEVEL_MAP[level] || level;
 }
 
 function getLevelBadgeClass(level) {
-    return LEVEL_BADGE_MAP[level] || 'badge-trial';
+	return LEVEL_BADGE_MAP[level] || "badge-trial";
 }
 
 function getStatusBadgeClass(status) {
-    return STATUS_BADGE_MAP[status] || 'badge-pending';
+	return STATUS_BADGE_MAP[status] || "badge-pending";
 }
 
 function debounce(func, wait) {
-    let timeout;
-    return function executedFunction(...args) {
-        const later = () => {
-            clearTimeout(timeout);
-            func(...args);
-        };
-        clearTimeout(timeout);
-        timeout = setTimeout(later, wait);
-    };
+	let timeout;
+	return function executedFunction(...args) {
+		const later = () => {
+			clearTimeout(timeout);
+			func(...args);
+		};
+		clearTimeout(timeout);
+		timeout = setTimeout(later, wait);
+	};
 }
 
 class FlashAccountManager {
-    constructor(page) {
-        this.page = page;
-        this.selected_request = null;
-        this.upgrade_requests = [];
-        this.current_page = 1;
-        this.page_size = 10;
-        this.total_pages = 1;
-        this.total_count = 0;
-        this.$cache = {};
-        this.setup_page();
-    }
+	constructor(page) {
+		this.page = page;
+		this.selected_request = null;
+		this.upgrade_requests = [];
+		this.current_page = 1;
+		this.page_size = 10;
+		this.total_pages = 1;
+		this.total_count = 0;
+		this.$cache = {};
+		this.setup_page();
+	}
 
-    setup_page() {
-        this.create_layout();
-        this.cache_elements();
-        this.bind_events();
-        this.load_upgrade_requests();
-    }
+	setup_page() {
+		this.create_layout();
+		this.cache_elements();
+		this.bind_events();
+		this.load_upgrade_requests();
+	}
 
-    cache_elements() {
-        const main = this.page.main;
-        this.$cache = {
-            searchInput: main.find('.search-input'),
-            requestsLoading: main.find('.requests-loading'),
-            requestsTable: main.find('.requests-list table'),
-            noRequests: main.find('.no-requests'),
-            requestDetails: main.find('.request-details'),
-            paginationControls: main.find('.pagination-controls'),
-            requestsTbody: main.find('.requests-tbody'),
-            searchLoading: main.find('.search-loading'),
-            searchError: main.find('.search-error'),
-            filterStatus: main.find('#filter-status'),
-            filterLevel: main.find('#filter-level')
-        };
-    }
+	cache_elements() {
+		const main = this.page.main;
+		this.$cache = {
+			searchInput: main.find(".search-input"),
+			requestsLoading: main.find(".requests-loading"),
+			requestsTable: main.find(".requests-list table"),
+			noRequests: main.find(".no-requests"),
+			requestDetails: main.find(".request-details"),
+			paginationControls: main.find(".pagination-controls"),
+			requestsTbody: main.find(".requests-tbody"),
+			searchLoading: main.find(".search-loading"),
+			searchError: main.find(".search-error"),
+			filterStatus: main.find("#filter-status"),
+			filterLevel: main.find("#filter-level"),
+		};
+	}
 
-    create_layout() {
-        this.page.main.html(`
+	create_layout() {
+		this.page.main.html(`
             <style>
                 .flash-account-manager {
                     --color-primary: #007856;
@@ -790,25 +790,25 @@ class FlashAccountManager {
                 </div>
             </div>
         `);
-    }
+	}
 
-    show_id_document(fileUrl) {
-        const d = new frappe.ui.Dialog({
-            title: 'ID Document',
-            size: 'large',
-            fields: [
-                {
-                    fieldtype: 'HTML',
-                    fieldname: 'preview',
-                }
-            ],
-            primary_action_label: 'Close',
-            primary_action() {
-                d.hide();
-            }
-        });
+	show_id_document(fileUrl) {
+		const d = new frappe.ui.Dialog({
+			title: "ID Document",
+			size: "large",
+			fields: [
+				{
+					fieldtype: "HTML",
+					fieldname: "preview",
+				},
+			],
+			primary_action_label: "Close",
+			primary_action() {
+				d.hide();
+			},
+		});
 
-        d.fields_dict.preview.$wrapper.html(`
+		d.fields_dict.preview.$wrapper.html(`
                 <div style="text-align:center;">
                     <img
                         src="${fileUrl}"
@@ -821,449 +821,486 @@ class FlashAccountManager {
                     />
                 </div>
             `);
-        d.show();
-    }
+		d.show();
+	}
 
-    prefetch_id_document_url(fileKey, containerEl) {
-        frappe.call({
-            method: 'admin_panel.api.admin_api.get_id_document_url',
-            args: { file_key: fileKey },
-            callback: (response) => {
-                if (response.message && response.message.success) {
-                    const preSignedUrl = response.message.url;
-                    containerEl.html(`
+	prefetch_id_document_url(fileKey, containerEl) {
+		frappe.call({
+			method: "admin_panel.api.admin_api.get_id_document_url",
+			args: { file_key: fileKey },
+			callback: (response) => {
+				if (response.message && response.message.success) {
+					const preSignedUrl = response.message.url;
+					containerEl.html(`
                         <button class="btn btn-sm btn-secondary btn-view-id-doc">
                             <i class="fa fa-eye"></i> View document
                         </button>
                     `);
-                    containerEl.find('.btn-view-id-doc').on('click', () => {
-                        this.show_id_document(preSignedUrl);
-                    });
-                } else {
-                    containerEl.html(`
+					containerEl.find(".btn-view-id-doc").on("click", () => {
+						this.show_id_document(preSignedUrl);
+					});
+				} else {
+					containerEl.html(`
                         <button class="btn btn-sm btn-danger btn-view-id-doc" disabled>
                             <i class="fa fa-exclamation-triangle"></i> Failed to load
                         </button>
                     `);
-                }
-            },
-            error: () => {
-                containerEl.html(`
+				}
+			},
+			error: () => {
+				containerEl.html(`
                     <button class="btn btn-sm btn-danger btn-view-id-doc" disabled>
                         <i class="fa fa-exclamation-triangle"></i> Failed to load
                     </button>
                 `);
-            }
-        });
-    }
+			},
+		});
+	}
 
-    bind_events() {
-        const main = this.page.main;
-        const debouncedSearch = debounce(() => {
-            if (this.$cache.searchInput.val().trim()) {
-                this.search();
-            } else {
-                this.$cache.searchError.hide();
-                this.load_upgrade_requests();
-            }
-        }, 300);
+	bind_events() {
+		const main = this.page.main;
+		const debouncedSearch = debounce(() => {
+			if (this.$cache.searchInput.val().trim()) {
+				this.search();
+			} else {
+				this.$cache.searchError.hide();
+				this.load_upgrade_requests();
+			}
+		}, 300);
 
-        main.find('.btn-search').on('click', () => this.search());
-        this.$cache.searchInput.on('keypress', (e) => { if (e.which === 13) this.search(); });
-        this.$cache.searchInput.on('input', debouncedSearch);
+		main.find(".btn-search").on("click", () => this.search());
+		this.$cache.searchInput.on("keypress", (e) => {
+			if (e.which === 13) this.search();
+		});
+		this.$cache.searchInput.on("input", debouncedSearch);
 
-        main.find('.btn-refresh').on('click', () => this.load_upgrade_requests());
-        main.find('.btn-close-details').on('click', () => this.$cache.requestDetails.hide());
-        main.find('.btn-approve').on('click', () => this.approve_request(this.selected_request));
-        main.find('.btn-reject').on('click', () => this.reject_request(this.selected_request));
+		main.find(".btn-refresh").on("click", () => this.load_upgrade_requests());
+		main.find(".btn-close-details").on("click", () => this.$cache.requestDetails.hide());
+		main.find(".btn-approve").on("click", () => this.approve_request(this.selected_request));
+		main.find(".btn-reject").on("click", () => this.reject_request(this.selected_request));
 
-        this.$cache.filterStatus.on('change', () => { this.current_page = 1; this.load_upgrade_requests(); });
-        this.$cache.filterLevel.on('change', () => { this.current_page = 1; this.load_upgrade_requests(); });
+		this.$cache.filterStatus.on("change", () => {
+			this.current_page = 1;
+			this.load_upgrade_requests();
+		});
+		this.$cache.filterLevel.on("change", () => {
+			this.current_page = 1;
+			this.load_upgrade_requests();
+		});
 
-        // Pagination events
-        main.find('.btn-first-page').on('click', () => this.go_to_page(1));
-        main.find('.btn-prev-page').on('click', () => this.go_to_page(this.current_page - 1));
-        main.find('.btn-next-page').on('click', () => this.go_to_page(this.current_page + 1));
-        main.find('.btn-last-page').on('click', () => this.go_to_page(this.total_pages));
-    }
+		// Pagination events
+		main.find(".btn-first-page").on("click", () => this.go_to_page(1));
+		main.find(".btn-prev-page").on("click", () => this.go_to_page(this.current_page - 1));
+		main.find(".btn-next-page").on("click", () => this.go_to_page(this.current_page + 1));
+		main.find(".btn-last-page").on("click", () => this.go_to_page(this.total_pages));
+	}
 
-    create_request_row(req, showActions = true) {
-        const levelBadge = getLevelBadgeClass(req.requested_level);
-        const displayStatus = req.status || AccountStatus.PENDING;
-        const statusBadge = getStatusBadgeClass(displayStatus);
-        const isPending = req.status === AccountStatus.PENDING;
+	create_request_row(req, showActions = true) {
+		const levelBadge = getLevelBadgeClass(req.requested_level);
+		const displayStatus = req.status || AccountStatus.PENDING;
+		const statusBadge = getStatusBadgeClass(displayStatus);
+		const isPending = req.status === AccountStatus.PENDING;
 
-        const actionsHtml = showActions && isPending
-            ? `<td style="text-align:center;">
+		const actionsHtml =
+			showActions && isPending
+				? `<td style="text-align:center;">
                 <button class="modern-icon-btn modern-icon-btn-success btn-quick-approve" data-request-id="${req.name}" title="Approve"><i class="fa fa-check"></i></button>
                 <button class="modern-icon-btn modern-icon-btn-danger btn-quick-reject" data-request-id="${req.name}" title="Reject"><i class="fa fa-times"></i></button>
                </td>`
-            : `<td style="text-align:center;"><span>-</span></td>`;
+				: `<td style="text-align:center;"><span>-</span></td>`;
 
-        const row = $(`
+		const row = $(`
             <tr class="request-row" data-request-id="${req.name}">
-                <td><strong>${req.username || '-'}</strong></td>
+                <td><strong>${req.username || "-"}</strong></td>
                 <td>${this.formatPhone(req.phone_number)}</td>
-                <td><span class="modern-badge ${levelBadge}">${getAccountLevelLabel(req.requested_level)}</span></td>
+                <td><span class="modern-badge ${levelBadge}">${getAccountLevelLabel(
+			req.requested_level
+		)}</span></td>
                 <td>${this.formatDateTime(req.creation)}</td>
                 <td><span class="modern-badge ${statusBadge}">${displayStatus}</span></td>
                 ${actionsHtml}
             </tr>
         `);
 
-        row.on('click', (e) => {
-            if (!$(e.target).closest('button').length) {
-                this.page.main.find('.request-row').removeClass('selected');
-                row.addClass('selected');
-                this.show_request_details(req);
-            }
-        });
+		row.on("click", (e) => {
+			if (!$(e.target).closest("button").length) {
+				this.page.main.find(".request-row").removeClass("selected");
+				row.addClass("selected");
+				this.show_request_details(req);
+			}
+		});
 
-        row.find('.btn-quick-approve').on('click', (e) => {
-            e.stopPropagation();
-            $(e.currentTarget).prop('disabled', true);
-            this.approve_request(req);
-        });
-        row.find('.btn-quick-reject').on('click', (e) => {
-            e.stopPropagation();
-            $(e.currentTarget).prop('disabled', true);
-            this.reject_request(req);
-        });
-        return row;
-    }
+		row.find(".btn-quick-approve").on("click", (e) => {
+			e.stopPropagation();
+			$(e.currentTarget).prop("disabled", true);
+			this.approve_request(req);
+		});
+		row.find(".btn-quick-reject").on("click", (e) => {
+			e.stopPropagation();
+			$(e.currentTarget).prop("disabled", true);
+			this.reject_request(req);
+		});
+		return row;
+	}
 
-    go_to_page(page) {
-        if (page < 1 || page > this.total_pages) return;
-        this.current_page = page;
-        this.load_upgrade_requests();
-    }
+	go_to_page(page) {
+		if (page < 1 || page > this.total_pages) return;
+		this.current_page = page;
+		this.load_upgrade_requests();
+	}
 
-    load_upgrade_requests() {
-        this.$cache.requestsLoading.show();
-        this.$cache.requestsTable.hide();
-        this.$cache.noRequests.hide();
-        this.$cache.requestDetails.hide();
-        this.$cache.paginationControls.hide();
+	load_upgrade_requests() {
+		this.$cache.requestsLoading.show();
+		this.$cache.requestsTable.hide();
+		this.$cache.noRequests.hide();
+		this.$cache.requestDetails.hide();
+		this.$cache.paginationControls.hide();
 
-        frappe.call({
-            method: 'admin_panel.api.admin_api.get_upgrade_requests',
-            args: {
-                status: this.$cache.filterStatus.val(),
-                requested_level: this.$cache.filterLevel.val(),
-                page: this.current_page,
-                page_size: this.page_size
-            },
-            callback: (response) => {
-                this.$cache.requestsLoading.hide();
-                const result = response.message || {};
-                this.upgrade_requests = result.data || [];
-                this.total_count = result.total || 0;
-                this.total_pages = result.total_pages || 1;
-                this.current_page = result.page || 1;
-                this.render_requests();
-                this.update_pagination();
-            },
-            error: () => {
-                this.$cache.requestsLoading.hide();
-                frappe.show_alert({ message: 'Failed to load upgrade requests', indicator: 'red' }, 5);
-            }
-        });
-    }
+		frappe.call({
+			method: "admin_panel.api.admin_api.get_upgrade_requests",
+			args: {
+				status: this.$cache.filterStatus.val(),
+				requested_level: this.$cache.filterLevel.val(),
+				page: this.current_page,
+				page_size: this.page_size,
+			},
+			callback: (response) => {
+				this.$cache.requestsLoading.hide();
+				const result = response.message || {};
+				this.upgrade_requests = result.data || [];
+				this.total_count = result.total || 0;
+				this.total_pages = result.total_pages || 1;
+				this.current_page = result.page || 1;
+				this.render_requests();
+				this.update_pagination();
+			},
+			error: () => {
+				this.$cache.requestsLoading.hide();
+				frappe.show_alert(
+					{ message: "Failed to load upgrade requests", indicator: "red" },
+					5
+				);
+			},
+		});
+	}
 
-    update_pagination() {
-        if (this.total_count === 0) {
-            this.$cache.paginationControls.hide();
-            return;
-        }
+	update_pagination() {
+		if (this.total_count === 0) {
+			this.$cache.paginationControls.hide();
+			return;
+		}
 
-        this.$cache.paginationControls.css('display', 'flex');
+		this.$cache.paginationControls.css("display", "flex");
 
-        const start = (this.current_page - 1) * this.page_size + 1;
-        const end = Math.min(this.current_page * this.page_size, this.total_count);
-        const main = this.page.main;
+		const start = (this.current_page - 1) * this.page_size + 1;
+		const end = Math.min(this.current_page * this.page_size, this.total_count);
+		const main = this.page.main;
 
-        main.find('.page-start').text(start);
-        main.find('.page-end').text(end);
-        main.find('.total-count').text(this.total_count);
-        main.find('.current-page').text(this.current_page);
-        main.find('.total-pages').text(this.total_pages);
+		main.find(".page-start").text(start);
+		main.find(".page-end").text(end);
+		main.find(".total-count").text(this.total_count);
+		main.find(".current-page").text(this.current_page);
+		main.find(".total-pages").text(this.total_pages);
 
-        main.find('.btn-first-page, .btn-prev-page').prop('disabled', this.current_page <= 1);
-        main.find('.btn-next-page, .btn-last-page').prop('disabled', this.current_page >= this.total_pages);
-    }
+		main.find(".btn-first-page, .btn-prev-page").prop("disabled", this.current_page <= 1);
+		main.find(".btn-next-page, .btn-last-page").prop(
+			"disabled",
+			this.current_page >= this.total_pages
+		);
+	}
 
-    render_requests() {
-        this.$cache.requestsTbody.empty();
+	render_requests() {
+		this.$cache.requestsTbody.empty();
 
-        if (this.upgrade_requests.length === 0) {
-            this.$cache.requestsTable.hide();
-            this.$cache.noRequests.show();
-            return;
-        }
+		if (this.upgrade_requests.length === 0) {
+			this.$cache.requestsTable.hide();
+			this.$cache.noRequests.show();
+			return;
+		}
 
-        this.$cache.requestsTable.show();
-        this.$cache.noRequests.hide();
+		this.$cache.requestsTable.show();
+		this.$cache.noRequests.hide();
 
-        this.upgrade_requests.forEach((req) => {
-            this.$cache.requestsTbody.append(this.create_request_row(req));
-        });
-    }
+		this.upgrade_requests.forEach((req) => {
+			this.$cache.requestsTbody.append(this.create_request_row(req));
+		});
+	}
 
-    show_request_details(req) {
-        this.selected_request = req;
-        const panel = this.page.main.find('.request-details');
+	show_request_details(req) {
+		this.selected_request = req;
+		const panel = this.page.main.find(".request-details");
 
-        const approveBtn = panel.find('.btn-approve');
-        const rejectBtn = panel.find('.btn-reject');
+		const approveBtn = panel.find(".btn-approve");
+		const rejectBtn = panel.find(".btn-reject");
 
-        // Show buttons only for pending requests (not approved, rejected, or closed)
-        if (req.status === AccountStatus.PENDING) {
-            approveBtn.show();
-            rejectBtn.show();
-        } else {
-            approveBtn.hide();
-            rejectBtn.hide();
-        }
+		// Show buttons only for pending requests (not approved, rejected, or closed)
+		if (req.status === AccountStatus.PENDING) {
+			approveBtn.show();
+			rejectBtn.show();
+		} else {
+			approveBtn.hide();
+			rejectBtn.hide();
+		}
 
-        const rejectionResonContainer = panel.find(".rejection-reason") 
-        if(req.support_note){
-            rejectionResonContainer.show()
-        }else{
-            rejectionResonContainer.hide()
-        }
-        
-        // Fill personal info
-        panel.find('.detail-username').text(req.username || '-');
-        panel.find('.detail-phone').text(this.formatPhone(req.phone_number) || '-');
-        panel.find('.detail-fullname').text(req.full_name || '-');
-        panel.find('.detail-email').text(req.email || '-');
+		const rejectionResonContainer = panel.find(".rejection-reason");
+		if (req.support_note) {
+			rejectionResonContainer.show();
+		} else {
+			rejectionResonContainer.hide();
+		}
 
-        // Business info
-        if (req.requested_level === AccountLevels.PRO || req.requested_level === AccountLevels.MERCHANT) {
-            panel.find('.business-info').show();
-            panel.find('.detail-business-name').text(req.address_title || '-');
-            panel.find('.detail-address-line1').text(req.address_line1 || '-');
-            panel.find('.detail-address-line2').text(req.address_line2 || '-');
-            panel.find('.detail-city').text(req.city || '-');
-            panel.find('.detail-state').text(req.state || '-');
-            panel.find('.detail-pincode').text(req.pincode || '-');
-            panel.find('.detail-country').text(req.country || '-');
-            panel.find('.detail-terminal-requested').text(req.terminal_requested ?? '-');
-        } else {
-            panel.find('.business-info').hide();
-        }
+		// Fill personal info
+		panel.find(".detail-username").text(req.username || "-");
+		panel.find(".detail-phone").text(this.formatPhone(req.phone_number) || "-");
+		panel.find(".detail-fullname").text(req.full_name || "-");
+		panel.find(".detail-email").text(req.email || "-");
 
-        // ID Document (PRO and MERCHANT)
-        const idDocItem = panel.find('.id-document-item');
-        if (req.requested_level === AccountLevels.PRO || req.requested_level === AccountLevels.MERCHANT) {
-            const idDocEl = panel.find('.detail-id-document');
-            idDocEl.empty();
+		// Business info
+		if (
+			req.requested_level === AccountLevels.PRO ||
+			req.requested_level === AccountLevels.MERCHANT
+		) {
+			panel.find(".business-info").show();
+			panel.find(".detail-business-name").text(req.address_title || "-");
+			panel.find(".detail-address-line1").text(req.address_line1 || "-");
+			panel.find(".detail-address-line2").text(req.address_line2 || "-");
+			panel.find(".detail-city").text(req.city || "-");
+			panel.find(".detail-state").text(req.state || "-");
+			panel.find(".detail-pincode").text(req.pincode || "-");
+			panel.find(".detail-country").text(req.country || "-");
+			panel.find(".detail-terminal-requested").text(req.terminal_requested ?? "-");
+		} else {
+			panel.find(".business-info").hide();
+		}
 
-            if (req.id_document) {
-                idDocEl.html(`
+		// ID Document (PRO and MERCHANT)
+		const idDocItem = panel.find(".id-document-item");
+		if (
+			req.requested_level === AccountLevels.PRO ||
+			req.requested_level === AccountLevels.MERCHANT
+		) {
+			const idDocEl = panel.find(".detail-id-document");
+			idDocEl.empty();
+
+			if (req.id_document) {
+				idDocEl.html(`
                     <button class="btn btn-sm btn-secondary btn-view-id-doc" disabled>
                         <i class="fa fa-spinner fa-spin"></i> Loading...
                     </button>
                 `);
-                this.prefetch_id_document_url(req.id_document, idDocEl);
-            } else {
-                idDocEl.text('-');
-            }
-            idDocItem.show();
-        } else {
-            idDocItem.hide();
-        }
+				this.prefetch_id_document_url(req.id_document, idDocEl);
+			} else {
+				idDocEl.text("-");
+			}
+			idDocItem.show();
+		} else {
+			idDocItem.hide();
+		}
 
-        // Bank info (required for MERCHANT, optional for PRO)
-        const hasBankInfo = req.bank_name || req.account_number || req.bank_branch;
-        const showBankInfo = req.requested_level === AccountLevels.MERCHANT ||
-                            (req.requested_level === AccountLevels.PRO && hasBankInfo);
+		// Bank info (required for MERCHANT, optional for PRO)
+		const hasBankInfo = req.bank_name || req.account_number || req.bank_branch;
+		const showBankInfo =
+			req.requested_level === AccountLevels.MERCHANT ||
+			(req.requested_level === AccountLevels.PRO && hasBankInfo);
 
-        if (showBankInfo) {
-            panel.find('.detail-bank-name').text(req.bank_name || '-');
-            panel.find('.detail-account-number').text(req.account_number || '-');
-            panel.find('.detail-account-type').text(req.account_type || '-');
-            panel.find('.detail-bank-branch').text(req.bank_branch || '-');
-            panel.find('.detail-currency').text(req.currency || '-');
-            panel.find('.bank-info-section').show();
-        } else {
-            panel.find('.bank-info-section').hide();
-        }
+		if (showBankInfo) {
+			panel.find(".detail-bank-name").text(req.bank_name || "-");
+			panel.find(".detail-account-number").text(req.account_number || "-");
+			panel.find(".detail-account-type").text(req.account_type || "-");
+			panel.find(".detail-bank-branch").text(req.bank_branch || "-");
+			panel.find(".detail-currency").text(req.currency || "-");
+			panel.find(".bank-info-section").show();
+		} else {
+			panel.find(".bank-info-section").hide();
+		}
 
-        // Request info
-        panel.find('.detail-current-level').text(getAccountLevelLabel(req.current_level) || '-');
-        panel.find('.detail-requested-level').text(getAccountLevelLabel(req.requested_level) || '-');
-        panel.find('.detail-status').text(req.status || '-');
-        panel.find('.detail-submitted').text(this.formatDateTime(req.creation));
-        panel.find('.detail-request-id').text(req.name);
-        panel.find('.detail-rejection-reason').text(req.support_note);
+		// Request info
+		panel.find(".detail-current-level").text(getAccountLevelLabel(req.current_level) || "-");
+		panel
+			.find(".detail-requested-level")
+			.text(getAccountLevelLabel(req.requested_level) || "-");
+		panel.find(".detail-status").text(req.status || "-");
+		panel.find(".detail-submitted").text(this.formatDateTime(req.creation));
+		panel.find(".detail-request-id").text(req.name);
+		panel.find(".detail-rejection-reason").text(req.support_note);
 
-        panel.show();
+		panel.show();
 
-        const row = this.page.main.find(`tr[data-request-id="${req.name}"]`);
-        if (row.length) {
-            row[0].scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-    }
+		const row = this.page.main.find(`tr[data-request-id="${req.name}"]`);
+		if (row.length) {
+			row[0].scrollIntoView({ behavior: "smooth", block: "start" });
+		}
+	}
 
-    approve_request(req) {
-        if (!req) return;
-        const levelLabel = getAccountLevelLabel(req.requested_level);
-        frappe.confirm(
-            `Are you sure you want to approve the upgrade request for ${req.username}? This will update the account level to ${levelLabel}.`,
-            () => frappe.call({
-                method: 'admin_panel.api.admin_api.approve_upgrade_request',
-                args: { request_id: req.name },
-                freeze: true,
-                freeze_message: "Approving request and updating account level...",
-                callback: (r) => {
-                    const result = r.message || {};
-                    if (result.success) {
-                        frappe.msgprint({
-                            title: 'Success',
-                            indicator: 'green',
-                            message: result.message || "Request approved and account level updated."
-                        });
-                        this.close_details();
-                        this.load_upgrade_requests();
-                    } else if (result.error || result.errors) {
-                        const errorMsg = result.error || result.errors?.join(', ') || 'Unknown error';
-                        frappe.msgprint({
-                            title: 'Error',
-                            indicator: 'red',
-                            message: errorMsg
-                        });
-                    }
-                },
-                error: (err) => {
-                    const msg = err?.responseJSON?.exception || err?.responseJSON?.message || 'Failed to approve request';
-                    frappe.msgprint({ title: 'Error', indicator: 'red', message: msg });
-                }
-            })
-        );
-    }
+	approve_request(req) {
+		if (!req) return;
+		const levelLabel = getAccountLevelLabel(req.requested_level);
+		frappe.confirm(
+			`Are you sure you want to approve the upgrade request for ${req.username}? This will update the account level to ${levelLabel}.`,
+			() =>
+				frappe.call({
+					method: "admin_panel.api.admin_api.approve_upgrade_request",
+					args: { request_id: req.name },
+					freeze: true,
+					freeze_message: "Approving request and updating account level...",
+					callback: (r) => {
+						const result = r.message || {};
+						if (result.success) {
+							frappe.msgprint({
+								title: "Success",
+								indicator: "green",
+								message:
+									result.message ||
+									"Request approved and account level updated.",
+							});
+							this.close_details();
+							this.load_upgrade_requests();
+						} else if (result.error || result.errors) {
+							const errorMsg =
+								result.error || result.errors?.join(", ") || "Unknown error";
+							frappe.msgprint({
+								title: "Error",
+								indicator: "red",
+								message: errorMsg,
+							});
+						}
+					},
+					error: (err) => {
+						const msg =
+							err?.responseJSON?.exception ||
+							err?.responseJSON?.message ||
+							"Failed to approve request";
+						frappe.msgprint({ title: "Error", indicator: "red", message: msg });
+					},
+				})
+		);
+	}
 
-    reject_request(req) {
-        if (!req) return;
+	reject_request(req) {
+		if (!req) return;
 
-        const d = new frappe.ui.Dialog({
-            title: "Reject Upgrade Request",
-            fields: [
-                {
-                    fieldname: "reason",
-                    fieldtype: "Small Text",
-                    label: "Reason for Rejection",
-                    reqd: 1
-                }
-            ],
-            primary_action_label: "Reject",
-            primary_action: (values) => {
-                frappe.call({
-                    method: 'admin_panel.api.admin_api.reject_upgrade_request',
-                    args: { request_id: req.name, reason: values.reason },
-                    freeze: true,
-                    freeze_message: "Rejecting request...",
-                    callback: (r) => {
-                        const result = r.message || {};
-                        if (result.success) {
-                            d.hide();
-                            frappe.msgprint({
-                                title: 'Request Rejected',
-                                indicator: 'orange',
-                                message: result.message || "Request rejected."
-                            });
-                            this.close_details();
-                            this.load_upgrade_requests();
-                        } else if (result.error || result.errors) {
-                            const errorMsg = result.error || result.errors?.join(', ') || 'Unknown error';
-                            frappe.msgprint({
-                                title: 'Error',
-                                indicator: 'red',
-                                message: errorMsg
-                            });
-                        }
-                    },
-                    error: (err) => {
-                        frappe.msgprint({
-                            title: 'Error',
-                            indicator: 'red',
-                            message: err.message || 'Failed to reject request'
-                        });
-                    }
-                });
-            }
-        });
+		const d = new frappe.ui.Dialog({
+			title: "Reject Upgrade Request",
+			fields: [
+				{
+					fieldname: "reason",
+					fieldtype: "Small Text",
+					label: "Reason for Rejection",
+					reqd: 1,
+				},
+			],
+			primary_action_label: "Reject",
+			primary_action: (values) => {
+				frappe.call({
+					method: "admin_panel.api.admin_api.reject_upgrade_request",
+					args: { request_id: req.name, reason: values.reason },
+					freeze: true,
+					freeze_message: "Rejecting request...",
+					callback: (r) => {
+						const result = r.message || {};
+						if (result.success) {
+							d.hide();
+							frappe.msgprint({
+								title: "Request Rejected",
+								indicator: "orange",
+								message: result.message || "Request rejected.",
+							});
+							this.close_details();
+							this.load_upgrade_requests();
+						} else if (result.error || result.errors) {
+							const errorMsg =
+								result.error || result.errors?.join(", ") || "Unknown error";
+							frappe.msgprint({
+								title: "Error",
+								indicator: "red",
+								message: errorMsg,
+							});
+						}
+					},
+					error: (err) => {
+						frappe.msgprint({
+							title: "Error",
+							indicator: "red",
+							message: err.message || "Failed to reject request",
+						});
+					},
+				});
+			},
+		});
 
-        d.show();
-    }
+		d.show();
+	}
 
-    close_details() {
-        this.$cache.requestDetails.hide();
-        this.selected_request = null;
-    }
+	close_details() {
+		this.$cache.requestDetails.hide();
+		this.selected_request = null;
+	}
 
-    search() {
-        const input = this.$cache.searchInput.val().trim();
-        if (!input) {
-            frappe.show_alert({ message: 'Please enter a username or phone number', indicator: 'orange' }, 3);
-            return;
-        }
+	search() {
+		const input = this.$cache.searchInput.val().trim();
+		if (!input) {
+			frappe.show_alert(
+				{ message: "Please enter a username or phone number", indicator: "orange" },
+				3
+			);
+			return;
+		}
 
-        this.$cache.searchLoading.show();
-        this.$cache.searchError.hide();
-        this.$cache.requestDetails.hide();
+		this.$cache.searchLoading.show();
+		this.$cache.searchError.hide();
+		this.$cache.requestDetails.hide();
 
-        frappe.call({
-            method: 'admin_panel.api.admin_api.search_account',
-            args: { id: input },
-            callback: (res) => {
-                this.$cache.searchLoading.hide();
-                const results = res.message;
-                if (!results || results.error) {
-                    this.show_search_error(results?.error || 'Account not found');
-                    return;
-                }
-                this.show_search_results(Array.isArray(results) ? results : []);
-            },
-            error: (e) => {
-                this.$cache.searchLoading.hide();
-                this.show_search_error(e.message || 'Account not found');
-            }
-        });
-    }
+		frappe.call({
+			method: "admin_panel.api.admin_api.search_account",
+			args: { id: input },
+			callback: (res) => {
+				this.$cache.searchLoading.hide();
+				const results = res.message;
+				if (!results || results.error) {
+					this.show_search_error(results?.error || "Account not found");
+					return;
+				}
+				this.show_search_results(Array.isArray(results) ? results : []);
+			},
+			error: (e) => {
+				this.$cache.searchLoading.hide();
+				this.show_search_error(e.message || "Account not found");
+			},
+		});
+	}
 
-    show_search_results(results) {
-        this.$cache.requestsTbody.empty();
-        this.$cache.searchError.hide();
-        this.$cache.paginationControls.hide();
+	show_search_results(results) {
+		this.$cache.requestsTbody.empty();
+		this.$cache.searchError.hide();
+		this.$cache.paginationControls.hide();
 
-        if (!results || !results.length) {
-            this.$cache.noRequests.show();
-            this.$cache.requestsTable.hide();
-            this.show_search_error('No accounts found');
-            return;
-        }
+		if (!results || !results.length) {
+			this.$cache.noRequests.show();
+			this.$cache.requestsTable.hide();
+			this.show_search_error("No accounts found");
+			return;
+		}
 
-        this.$cache.noRequests.hide();
-        this.$cache.requestsTable.show();
+		this.$cache.noRequests.hide();
+		this.$cache.requestsTable.show();
 
-        results.forEach(account => {
-            this.$cache.requestsTbody.append(this.create_request_row(account, true));
-        });
-    }
+		results.forEach((account) => {
+			this.$cache.requestsTbody.append(this.create_request_row(account, true));
+		});
+	}
 
-    show_search_error(msg) {
-        this.$cache.searchLoading.hide();
-        this.$cache.searchError.show();
-        this.page.main.find('.error-message').text(msg);
-    }
+	show_search_error(msg) {
+		this.$cache.searchLoading.hide();
+		this.$cache.searchError.show();
+		this.page.main.find(".error-message").text(msg);
+	}
 
-    formatPhone(phone) {
-        if (!phone) return '-';
-        return phone.replace(/^(\d{3})(\d{3})(\d{2})(\d{2})$/, '+$1 $2 $3 $4');
-    }
+	formatPhone(phone) {
+		if (!phone) return "-";
+		return phone.replace(/^(\d{3})(\d{3})(\d{2})(\d{2})$/, "+$1 $2 $3 $4");
+	}
 
-    formatDateTime(dt) {
-        return dt ? frappe.datetime.str_to_user(dt) : '-';
-    }
+	formatDateTime(dt) {
+		return dt ? frappe.datetime.str_to_user(dt) : "-";
+	}
 }

--- a/admin_panel/admin_panel/page/account_management/account_management.js
+++ b/admin_panel/admin_panel/page/account_management/account_management.js
@@ -23,7 +23,7 @@ frappe.pages["account-management"].on_page_load = function (wrapper) {
 		single_column: true,
 	});
 
-	new FlashAccountManager(page);
+	wrapper.account_management = new FlashAccountManager(page);
 };
 
 const AccountLevels = {
@@ -113,6 +113,7 @@ class FlashAccountManager {
 			requestsTable: main.find(".requests-list table"),
 			noRequests: main.find(".no-requests"),
 			requestDetails: main.find(".request-details"),
+			pulseTiles: main.find(".pulse-tiles"),
 			paginationControls: main.find(".pagination-controls"),
 			requestsTbody: main.find(".requests-tbody"),
 			searchLoading: main.find(".search-loading"),
@@ -125,379 +126,200 @@ class FlashAccountManager {
 	create_layout() {
 		this.page.main.html(`
             <style>
+                /* ═══ Ops-pulse design system — Account Management (approval queue) ═══
+                   Every selector is scoped under .flash-account-manager: the old
+                   block leaked global .modern-* rules into sibling desk pages. */
                 .flash-account-manager {
-                    --color-primary: #007856;
-                    --color-background: #F1F1F1;
-                    --color-layer: #FFFFFF;
-                    --color-text01: #212121;
-                    --color-text02: #939998;
-                    --color-border01: #DDE3E1;
-                    --color-green: #00A700;
-                    --color-error: #DC2626;
-                    --color-warning: #F59E0B;
+                    --am-surface: var(--card-bg, #ffffff); --am-ink: var(--text-color, #1a2420);
+                    --am-ink2: var(--text-muted, #5c6b65); --am-ink3: var(--text-light, #8fa098);
+                    --am-line: var(--border-color, #e2e8e5); --am-line-soft: var(--subtle-fg, #ecf1ee);
+                    --am-accent: #007856; --am-accent-ink: #007856; --am-accent-soft: #e6f3ee;
+                    --am-good: #0ca30c; --am-warn: #b87d00; --am-warn-bg: #fff3d6;
+                    --am-serious: #c05a32; --am-serious-bg: #fdeae2;
+                    --am-shadow: 0 1px 2px rgba(26,36,32,0.05), 0 4px 14px rgba(26,36,32,0.04);
+                    /* legacy aliases */
+                    --color-primary: var(--am-accent); --color-background: transparent;
+                    --color-layer: var(--am-surface); --color-text01: var(--am-ink);
+                    --color-text02: var(--am-ink2); --color-border01: var(--am-line);
+                    --color-green: var(--am-good); --color-error: var(--am-serious);
+                    --color-warning: var(--am-warn);
+                    max-width: 1400px; margin: 0 auto;
                 }
-                
-                .flash-account-manager {
-                    max-width: 1400px;
-                    margin: 0 auto;
-                }
-                
-                .modern-search-card {
-                    background: var(--color-layer);
-                    border-radius: 16px;
-                    padding: 24px;
-                    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-                    border: 1px solid var(--color-border01);
-                    margin-bottom: 24px;
-                }
-                
-                .modern-search-wrapper {
-                    display: flex;
-                    gap: 12px;
-                    align-items: center;
-                }
-                
-                .modern-search-input {
-                    flex: 1;
-                    max-width: 450px;
-                    padding: 12px 16px;
-                    border: 2px solid var(--color-border01);
-                    border-radius: 12px;
-                    font-size: 15px;
-                    transition: all 0.2s ease;
-                    background: var(--color-layer);
-                    color: var(--color-text01);
-                }
-                
-                .modern-search-input:focus {
-                    outline: none;
-                    border-color: var(--color-primary);
-                    box-shadow: 0 0 0 3px rgba(0, 120, 86, 0.1);
-                }
-                
-                .modern-search-input::placeholder {
-                    color: var(--color-text02);
+                [data-theme="dark"] .flash-account-manager, .dark .flash-account-manager {
+                    --am-accent: #1e9e75; --am-accent-ink: #4cc29e; --am-accent-soft: #12352a;
+                    --am-good: #35c135; --am-warn: #fab219; --am-warn-bg: #33290d;
+                    --am-serious: #ec835a; --am-serious-bg: #38211a;
+                    --am-shadow: 0 1px 2px rgba(0,0,0,0.35), 0 6px 18px rgba(0,0,0,0.25);
                 }
 
-                .modern-search-select {
-                    max-width: 250px;
-                }
+                /* queue pulse tiles */
+                .flash-account-manager .tr-tiles { display: grid;
+                    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+                    gap: 12px; margin-bottom: 14px; }
+                .flash-account-manager .tr-tile { background: var(--am-surface);
+                    border: 1px solid var(--am-line); border-radius: 14px;
+                    box-shadow: var(--am-shadow); padding: 12px 16px; }
+                .flash-account-manager .tr-tile-label { font-size: 11px; letter-spacing: 0.06em;
+                    text-transform: uppercase; color: var(--am-ink2); font-weight: 650; }
+                .flash-account-manager .tr-tile-value { font-size: 22px; font-weight: 650;
+                    color: var(--am-ink); font-variant-numeric: tabular-nums; margin-top: 2px; }
+                .flash-account-manager .tr-tile-value.warn { color: var(--am-warn); }
+                .flash-account-manager .tr-tile-value.bad { color: var(--am-serious); }
+                .flash-account-manager .tr-tile-sub { font-size: 11.5px; color: var(--am-ink3);
+                    margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-                .modern-btn {
-                    padding: 12px 24px;
-                    border-radius: 12px;
-                    font-weight: 500;
-                    font-size: 15px;
-                    border: none;
-                    cursor: pointer;
-                    transition: all 0.2s ease;
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 8px;
-                }
-                
-                .modern-btn-primary {
-                    background: var(--color-primary);
-                    color: white;
-                }
-                
-                .modern-btn-primary:hover {
-                    background: #005a42;
-                    transform: translateY(-1px);
-                    box-shadow: 0 4px 12px rgba(0, 120, 86, 0.2);
-                }
-                
-                .modern-btn-secondary {
-                    background: var(--color-layer);
-                    color: var(--color-text01);
-                    border: 2px solid var(--color-border01);
-                }
-                
-                .modern-btn-secondary:hover {
-                    background: var(--color-background);
-                    border-color: var(--color-text02);
-                }
-                
-                .modern-requests-card {
-                    background: var(--color-layer);
-                    border-radius: 16px;
-                    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-                    border: 1px solid var(--color-border01);
-                    overflow: hidden;
-                    margin-bottom: 24px;
-                }
-                
-                .modern-card-header {
-                    padding: 20px 24px;
-                    background: linear-gradient(135deg, var(--color-primary) 0%, #005a42 100%);
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                }
-                
-                .modern-card-title {
-                    font-size: 20px;
-                    font-weight: 600;
-                    color: white;
-                    margin: 0;
-                }
-                
-                .modern-table-wrapper {
-                    overflow-x: auto;
-                }
-                
-                .modern-table {
-                    width: 100%;
-                    border-collapse: separate;
-                    border-spacing: 0;
-                }
-                
-                .modern-table thead {
-                    background: var(--color-background);
-                }
-                
-                .modern-table th {
-                    padding: 16px 20px;
-                    text-align: left;
-                    font-size: 13px;
-                    font-weight: 600;
-                    color: var(--color-text02);
-                    text-transform: uppercase;
-                    letter-spacing: 0.5px;
-                    border-bottom: 2px solid var(--color-border01);
-                }
-                
-                .modern-table tbody tr {
-                    cursor: pointer;
-                    transition: all 0.2s ease;
-                    border-bottom: 1px solid var(--color-border01);
-                }
-                
-                .modern-table tbody tr:hover {
-                    background: rgba(0, 120, 86, 0.03);
-                }
-                
-                .modern-table tbody tr.selected {
-                    background: rgba(0, 120, 86, 0.15) !important;
-                    border-left: 4px solid var(--color-primary);
-                }
-                
-                .modern-table td {
-                    padding: 16px 20px;
-                    color: var(--color-text01);
-                    font-size: 14px;
-                }
-                
-                .modern-badge {
-                    display: inline-flex;
-                    align-items: center;
-                    padding: 6px 12px;
-                    border-radius: 20px;
-                    font-size: 12px;
-                    font-weight: 600;
-                    text-transform: uppercase;
-                    letter-spacing: 0.5px;
-                }
-                
-                .badge-trial {
-                    background: rgba(148, 163, 159, 0.15);
-                    color: var(--color-text02);
-                }
+                /* toolbar */
+                .flash-account-manager .modern-search-card { background: var(--am-surface);
+                    border: 1px solid var(--am-line); border-radius: 14px;
+                    box-shadow: var(--am-shadow); padding: 14px 16px; margin-bottom: 14px; }
+                .flash-account-manager .modern-search-wrapper { display: flex; gap: 10px;
+                    flex-wrap: wrap; align-items: center; }
+                .flash-account-manager .modern-search-wrapper[style*="margin-bottom"] {
+                    margin-bottom: 10px !important; }
+                .flash-account-manager .modern-search-input { flex: 1; min-width: 220px;
+                    padding: 8px 13px; border: 1px solid var(--am-line); border-radius: 10px;
+                    font-size: 13.5px; background: var(--am-surface); color: var(--am-ink); }
+                .flash-account-manager .modern-search-input:focus { outline: 2px solid var(--am-accent);
+                    outline-offset: 1px; border-color: var(--am-accent); }
+                .flash-account-manager .modern-search-input::placeholder { color: var(--am-ink3); }
+                .flash-account-manager .modern-search-select { flex: 0 1 240px; min-width: 180px;
+                    appearance: auto; }
 
-                .badge-personal {
-                    background: rgba(0, 120, 86, 0.1);
-                    color: var(--color-primary);
-                }
-                
-                .badge-business {
-                    background: rgba(232, 211, 21, 0.15);
-                    color: #b8a00e;
-                }
-                
-                .badge-merchant {
-                    background: rgba(245, 158, 11, 0.15);
-                    color: var(--color-warning);
-                }
-                
-                .badge-pending {
-                    background: rgba(245, 158, 11, 0.15);
-                    color: var(--color-warning);
-                }
+                /* buttons */
+                .flash-account-manager .modern-btn { display: inline-flex; align-items: center;
+                    gap: 6px; border: 1px solid var(--am-line); background: var(--am-surface);
+                    color: var(--am-ink); border-radius: 9px; padding: 7px 14px; font-size: 13px;
+                    font-weight: 600; cursor: pointer; transition: all 0.13s; }
+                .flash-account-manager .modern-btn:hover { border-color: var(--am-accent); }
+                .flash-account-manager .modern-btn:focus-visible { outline: 2px solid var(--am-accent);
+                    outline-offset: 1px; }
+                .flash-account-manager .modern-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+                .flash-account-manager .modern-btn-primary { background: var(--am-accent);
+                    border-color: var(--am-accent); color: #fff; }
+                .flash-account-manager .modern-btn-primary:hover { filter: brightness(1.07); }
+                .flash-account-manager .modern-btn-danger { color: var(--am-serious);
+                    border-color: var(--am-serious); background: transparent; }
+                .flash-account-manager .modern-btn-danger:hover { background: var(--am-serious-bg); }
 
-                .badge-approved {
-                    background: #d4f7d9;
-                    color: #15803d;
-                }
+                /* quick actions — approve/reject icon buttons */
+                .flash-account-manager .modern-icon-btn { width: 28px; height: 28px;
+                    display: inline-grid; place-items: center; border-radius: 8px;
+                    border: 1px solid var(--am-line); background: var(--am-surface);
+                    color: var(--am-ink2); cursor: pointer; margin: 0 2px;
+                    font-size: 12px; transition: all 0.13s; }
+                .flash-account-manager .modern-icon-btn:hover { border-color: currentColor; }
+                .flash-account-manager .modern-icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+                .flash-account-manager .modern-icon-btn-success { color: var(--am-good); }
+                .flash-account-manager .modern-icon-btn-success:hover { background: var(--am-accent-soft); }
+                .flash-account-manager .modern-icon-btn-danger { color: var(--am-serious); }
+                .flash-account-manager .modern-icon-btn-danger:hover { background: var(--am-serious-bg); }
 
-                .badge-rejected {
-                    background: #fde2e2;
-                    color: #b91c1c;
-                }
+                /* cards */
+                .flash-account-manager .modern-requests-card { background: var(--am-surface);
+                    border: 1px solid var(--am-line); border-radius: 14px;
+                    box-shadow: var(--am-shadow); overflow: hidden; margin-bottom: 14px; }
+                .flash-account-manager .modern-card-header { display: flex; align-items: center;
+                    justify-content: space-between; gap: 12px; padding: 13px 18px;
+                    border-bottom: 1px solid var(--am-line); }
+                .flash-account-manager .modern-card-title { margin: 0; font-size: 13.5px;
+                    font-weight: 650; color: var(--am-ink); display: flex; align-items: center; }
+                .flash-account-manager .modern-card-title .fa { color: var(--am-accent-ink); }
 
-                .badge-closed {
-                    background: rgba(100, 116, 139, 0.15);
-                    color: #475569;
-                }
+                /* table */
+                .flash-account-manager .modern-table-wrapper { overflow-x: auto; }
+                .flash-account-manager .modern-table { width: 100%; border-collapse: collapse;
+                    font-size: 13px; }
+                .flash-account-manager .modern-table th { text-align: left; font-size: 11px;
+                    letter-spacing: 0.05em; text-transform: uppercase; color: var(--am-ink2);
+                    font-weight: 650; padding: 10px 14px; border-bottom: 1px solid var(--am-line);
+                    white-space: nowrap; }
+                .flash-account-manager .modern-table td { padding: 10px 14px;
+                    border-bottom: 1px solid var(--am-line-soft); color: var(--am-ink);
+                    font-variant-numeric: tabular-nums; }
+                .flash-account-manager .modern-table td strong { font-weight: 600; }
+                .flash-account-manager .modern-table tbody tr { cursor: pointer;
+                    border-left: 3px solid transparent; transition: background 0.12s; }
+                .flash-account-manager .modern-table tbody tr:hover { background: var(--am-line-soft); }
+                .flash-account-manager .modern-table tbody tr.selected { background: var(--am-accent-soft);
+                    border-left-color: var(--am-accent); }
+                .flash-account-manager .modern-table tbody tr:last-child td { border-bottom: none; }
 
-                .modern-icon-btn {
-                    padding: 8px 12px;
-                    border-radius: 8px;
-                    border: none;
-                    cursor: pointer;
-                    transition: all 0.2s ease;
-                    font-size: 14px;
-                    margin: 0 4px;
-                }
-                
-                .modern-icon-btn-success {
-                    background: rgba(0, 167, 0, 0.1);
-                    color: var(--color-green);
-                }
-                
-                .modern-icon-btn-success:hover {
-                    background: var(--color-green);
-                    color: white;
-                    transform: scale(1.05);
-                }
-                
-                .modern-icon-btn-danger {
-                    background: rgba(220, 38, 38, 0.1);
-                    color: var(--color-error);
-                }
-                
-                .modern-icon-btn-danger:hover {
-                    background: var(--color-error);
-                    color: white;
-                    transform: scale(1.05);
-                }
-                
-                .no-requests {
-                    padding: 60px 20px;
-                    text-align: center;
-                    color: var(--color-text02);
-                }
-                
-                .no-requests-icon {
-                    font-size: 48px;
-                    margin-bottom: 16px;
-                    opacity: 0.3;
-                }
-                
-                .loading-spinner {
-                    padding: 60px 20px;
-                    text-align: center;
-                }
-                
-                .spinner {
-                    width: 40px;
-                    height: 40px;
-                    border: 3px solid var(--color-border01);
-                    border-top-color: var(--color-primary);
-                    border-radius: 50%;
-                    animation: spin 0.8s linear infinite;
-                    margin: 0 auto 16px;
-                }
-                
-                @keyframes spin {
-                    to { transform: rotate(360deg); }
-                }
-                
-                .section-header {
-                    font-size: 16px;
-                    font-weight: 600;
-                    color: var(--color-text01);
-                    margin-bottom: 16px;
-                    padding-bottom: 12px;
-                    border-bottom: 2px solid var(--color-border01);
-                }
-                
-                .detail-item {
-                    margin-bottom: 16px;
-                    display: flex;
-                    flex-direction: column;
-                    gap: 4px;
-                }
-                
-                .detail-label {
-                    font-size: 12px;
-                    font-weight: 600;
-                    color: var(--color-text02);
-                    text-transform: uppercase;
-                    letter-spacing: 0.5px;
-                }
-                
-                .detail-value {
-                    font-size: 15px;
-                    color: var(--color-text01);
-                    font-weight: 500;
-                }
+                /* row age chips */
+                .flash-account-manager .tr-age { display: inline-flex; border-radius: 999px;
+                    padding: 2px 8px; font-size: 11px; font-weight: 650; margin-left: 8px;
+                    background: var(--am-line-soft); color: var(--am-ink2); }
+                .flash-account-manager .tr-age.warn { background: var(--am-warn-bg); color: var(--am-warn); }
+                .flash-account-manager .tr-age.bad { background: var(--am-serious-bg); color: var(--am-serious); }
 
-                .notes-box {
-                    background: var(--color-background);
-                    padding: 16px;
-                    border-radius: 8px;
-                    font-size: 14px;
-                    color: var(--color-text01);
-                    margin-top: 8px;
-                    line-height: 1.6;
-                    border: 1px solid var(--color-border01);
-                }
+                /* chips — level ramp mirrors Account Hub; status is semantic */
+                .flash-account-manager .modern-badge { display: inline-flex; align-items: center;
+                    border-radius: 999px; padding: 3px 11px; font-size: 11.5px; font-weight: 650;
+                    letter-spacing: 0.02em; white-space: nowrap; }
+                .flash-account-manager .badge-trial { background: var(--am-line-soft); color: var(--am-ink2); }
+                .flash-account-manager .badge-personal { background: var(--am-accent-soft);
+                    color: var(--am-accent-ink); opacity: 0.85; }
+                .flash-account-manager .badge-business { background: var(--am-accent-soft);
+                    color: var(--am-accent-ink); }
+                .flash-account-manager .badge-merchant { background: var(--am-accent); color: #fff; }
+                .flash-account-manager .badge-pending { background: var(--am-warn-bg); color: var(--am-warn); }
+                .flash-account-manager .badge-approved { background: var(--am-accent-soft);
+                    color: var(--am-accent-ink); }
+                .flash-account-manager .badge-rejected { background: var(--am-serious-bg);
+                    color: var(--am-serious); }
+                .flash-account-manager .badge-closed { background: var(--am-line-soft); color: var(--am-ink3); }
 
-                /* MOBILE UI IMPROVEMENTS */
-                @media (max-width: 768px) {
-                    .modern-search-wrapper {
-                        flex-direction: column;
-                        align-items: stretch;
-                    }
+                /* empty + loading */
+                .flash-account-manager .no-requests { text-align: center; padding: 40px 20px;
+                    color: var(--am-ink3); }
+                .flash-account-manager .no-requests-icon { font-size: 26px; margin-bottom: 8px;
+                    filter: grayscale(0.4); opacity: 0.75; }
+                .flash-account-manager .no-requests p:first-of-type { color: var(--am-ink); margin: 0; }
+                .flash-account-manager .no-requests p { margin: 4px 0 0; }
+                .flash-account-manager .loading-spinner { text-align: center; padding: 34px 0; }
+                .flash-account-manager .loading-spinner p { margin: 8px 0 0; font-size: 12.5px; }
+                .flash-account-manager .spinner { width: 22px; height: 22px;
+                    border: 2px solid var(--am-line); border-top-color: var(--am-accent);
+                    border-radius: 50%; margin: 0 auto; animation: am-spin 0.8s linear infinite; }
+                @keyframes am-spin { to { transform: rotate(360deg); } }
 
-                    .modern-search-input {
-                        max-width: 100%;
-                        width: 100%;
-                    }
+                /* detail drawer */
+                .flash-account-manager .detail-section { margin-bottom: 18px; }
+                .flash-account-manager .section-header { font-size: 11px; letter-spacing: 0.06em;
+                    text-transform: uppercase; color: var(--am-ink2); font-weight: 650;
+                    margin: 0 0 8px; display: flex; align-items: center; }
+                .flash-account-manager .detail-item { display: flex; justify-content: space-between;
+                    gap: 12px; align-items: baseline; padding: 6px 0;
+                    border-bottom: 1px solid var(--am-line-soft); }
+                .flash-account-manager .detail-label { font-size: 11px; letter-spacing: 0.05em;
+                    text-transform: uppercase; color: var(--am-ink2); font-weight: 600; flex: none; }
+                .flash-account-manager .detail-value { font-size: 13px; font-weight: 600;
+                    color: var(--am-ink); text-align: right; word-break: break-word; min-width: 0;
+                    font-variant-numeric: tabular-nums; }
+                .flash-account-manager .notes-box { background: var(--am-serious-bg);
+                    color: var(--am-serious); border-radius: 10px; padding: 10px 14px;
+                    font-size: 12.5px; font-weight: 600; margin: 6px 0 0; white-space: pre-wrap; }
+                .flash-account-manager .request-details { position: fixed; top: 0; right: 0;
+                    bottom: 0; width: min(620px, 94vw); z-index: 1040; margin: 0;
+                    border-radius: 16px 0 0 16px; border-right: none;
+                    box-shadow: -20px 0 50px rgba(26, 36, 32, 0.18); overflow-y: auto; }
+                [data-theme="dark"] .flash-account-manager .request-details,
+                .dark .flash-account-manager .request-details {
+                    box-shadow: -20px 0 50px rgba(0, 0, 0, 0.5); }
+                .flash-account-manager .request-details .modern-card-header { position: sticky;
+                    top: 0; background: var(--am-surface); z-index: 1; }
 
-                    .modern-btn {
-                        width: 100%;
-                        justify-content: center;
-                    }
-
-                    .modern-table th, 
-                    .modern-table td {
-                        padding: 12px 10px;
-                        font-size: 13px;
-                    }
-
-                    /* Make table horizontally scrollable */
-                    .modern-table-wrapper {
-                        overflow-x: auto;
-                    }
-
-                    /* Remove fixed paddings on cards */
-                    .modern-search-card,
-                    .modern-requests-card {
-                        padding: 16px !important;
-                    }
-
-                    .modern-icon-btn-success {
-                        margin-bottom: 5px;
-                    }
-
-                    /* Details panel spacing */
-                    .request-details .card-body {
-                        padding: 16px !important;
-                    }
-
-                    /* Stack action buttons */
-                    .request-details .d-flex {
-                        flex-direction: column;
-                    }
-
-                    .request-details .d-flex button {
-                        width: 100%;
-                    }
+                @media (prefers-reduced-motion: no-preference) {
+                    .flash-account-manager .modern-requests-card { animation: am-rise 0.3s ease; }
+                    @keyframes am-rise { from { opacity: 0; transform: translateY(5px); } }
+                    .flash-account-manager .request-details { animation: am-slide 0.22s ease; }
+                    @keyframes am-slide { from { opacity: 0.4; transform: translateX(40px); } }
                 }
             </style>
 
             <div class="flash-account-manager m-3">
+                <!-- Queue pulse -->
+                <div class="tr-tiles pulse-tiles" style="display:none;"></div>
+
                 <!-- Search Bar -->
                 <div class="modern-search-card">
                     <div class="modern-search-wrapper" style="margin-bottom:20px;">
@@ -768,7 +590,7 @@ class FlashAccountManager {
                                 <i class="fa fa-check"></i>
                                 Approve
                             </button>
-                            <button class="modern-btn modern-btn-primary btn-reject" style="background: var(--color-error);">
+                            <button class="modern-btn modern-btn-danger btn-reject">
                                 <i class="fa fa-times"></i>
                                 Reject
                             </button>
@@ -875,6 +697,12 @@ class FlashAccountManager {
 		this.$cache.searchInput.on("input", debouncedSearch);
 
 		main.find(".btn-refresh").on("click", () => this.load_upgrade_requests());
+
+		$(document).on("keydown.account_management", (e) => {
+			if (e.key === "Escape" && !window.cur_dialog) {
+				this.close_details();
+			}
+		});
 		main.find(".btn-close-details").on("click", () => this.$cache.requestDetails.hide());
 		main.find(".btn-approve").on("click", () => this.approve_request(this.selected_request));
 		main.find(".btn-reject").on("click", () => this.reject_request(this.selected_request));
@@ -916,7 +744,7 @@ class FlashAccountManager {
                 <td><span class="modern-badge ${levelBadge}">${getAccountLevelLabel(
 			req.requested_level
 		)}</span></td>
-                <td>${this.formatDateTime(req.creation)}</td>
+                <td>${this.formatDateTime(req.creation)}${this.render_age_chip(req)}</td>
                 <td><span class="modern-badge ${statusBadge}">${displayStatus}</span></td>
                 ${actionsHtml}
             </tr>
@@ -949,7 +777,79 @@ class FlashAccountManager {
 		this.load_upgrade_requests();
 	}
 
+	formatAge(dateStr) {
+		const then = new Date(dateStr);
+		if (isNaN(then)) return "";
+		const mins = Math.max(0, Math.floor((Date.now() - then.getTime()) / 60000));
+		if (mins < 60) return `${mins}m`;
+		const hours = Math.floor(mins / 60);
+		if (hours < 24) return `${hours}h`;
+		return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+	}
+
+	age_tone(dateStr) {
+		const then = new Date(dateStr);
+		if (isNaN(then)) return "";
+		const hours = (Date.now() - then.getTime()) / 3600e3;
+		if (hours >= 24) return "bad";
+		if (hours >= 6) return "warn";
+		return "";
+	}
+
+	render_age_chip(req) {
+		if (req.status !== AccountStatus.PENDING || !req.creation) return "";
+		const age = this.formatAge(req.creation);
+		if (!age) return "";
+		return `<span class="tr-age ${this.age_tone(req.creation)}">${age}</span>`;
+	}
+
+	load_pulse() {
+		frappe.call({
+			method: "admin_panel.api.pulse.get_upgrade_pulse",
+			callback: (res) => {
+				this.pulse = res.message;
+				this.render_pulse();
+			},
+			error: () => this.$cache.pulseTiles.hide(),
+		});
+	}
+
+	render_pulse() {
+		if (!this.pulse) return;
+		const c = this.pulse;
+		const tiles = [
+			{ label: "Pending", value: c.pending ?? 0 },
+			{
+				label: "Oldest Waiting",
+				value: c.oldest_at ? this.formatAge(c.oldest_at) : "\u2014",
+				tone: c.oldest_at ? this.age_tone(c.oldest_at) : "",
+				sub: c.oldest_who || "queue clear",
+			},
+			{ label: "Processed (7d)", value: c.processed_week ?? 0 },
+		];
+		this.$cache.pulseTiles.html(
+			tiles
+				.map(
+					(t) => `
+                <div class="tr-tile">
+                    <div class="tr-tile-label">${t.label}</div>
+                    <div class="tr-tile-value ${t.tone || ""}">${frappe.utils.escape_html(
+						String(t.value)
+					)}</div>
+                    ${
+						t.sub
+							? `<div class="tr-tile-sub">${frappe.utils.escape_html(t.sub)}</div>`
+							: ""
+					}
+                </div>`
+				)
+				.join("")
+		);
+		this.$cache.pulseTiles.show();
+	}
+
 	load_upgrade_requests() {
+		this.load_pulse();
 		this.$cache.requestsLoading.show();
 		this.$cache.requestsTable.hide();
 		this.$cache.noRequests.hide();
@@ -1125,11 +1025,6 @@ class FlashAccountManager {
 		panel.find(".detail-rejection-reason").text(req.support_note);
 
 		panel.show();
-
-		const row = this.page.main.find(`tr[data-request-id="${req.name}"]`);
-		if (row.length) {
-			row[0].scrollIntoView({ behavior: "smooth", block: "start" });
-		}
 	}
 
 	approve_request(req) {

--- a/admin_panel/admin_panel/page/alert_users/alert_users.js
+++ b/admin_panel/admin_panel/page/alert_users/alert_users.js
@@ -1,11 +1,11 @@
-frappe.pages['alert-users'].on_page_load = function(wrapper) {
-    var page = frappe.ui.make_app_page({
-        parent: wrapper,
-        title: 'Alert Users',
-        single_column: true
-    });
+frappe.pages["alert-users"].on_page_load = function (wrapper) {
+	var page = frappe.ui.make_app_page({
+		parent: wrapper,
+		title: "Alert Users",
+		single_column: true,
+	});
 
-    page.main.html(`
+	page.main.html(`
         <style>
             .alert-form-container {
                 max-width: 800px;
@@ -269,138 +269,148 @@ frappe.pages['alert-users'].on_page_load = function(wrapper) {
         </div>
     `);
 
-    const $titleInput = page.main.find('#alert-title');
-    const $descriptionInput = page.main.find('#alert-description');
-    const $tagSelect = page.main.find('#alert-tag');
-    const $sendButton = page.main.find('#send-alert-btn');
-    const $titleCount = page.main.find('#title-count');
-    const $descriptionCount = page.main.find('#description-count');
-    const $previewContainer = page.main.find('#alert-preview');
-    const $previewTitle = page.main.find('#preview-title');
-    const $previewDescription = page.main.find('#preview-description');
-    const $previewTag = page.main.find('#preview-tag');
+	const $titleInput = page.main.find("#alert-title");
+	const $descriptionInput = page.main.find("#alert-description");
+	const $tagSelect = page.main.find("#alert-tag");
+	const $sendButton = page.main.find("#send-alert-btn");
+	const $titleCount = page.main.find("#title-count");
+	const $descriptionCount = page.main.find("#description-count");
+	const $previewContainer = page.main.find("#alert-preview");
+	const $previewTitle = page.main.find("#preview-title");
+	const $previewDescription = page.main.find("#preview-description");
+	const $previewTag = page.main.find("#preview-tag");
 
-    function updatePreview() {
-        const title = $titleInput.val().trim();
-        const description = $descriptionInput.val().trim();
-        const tag = $tagSelect.val();
+	function updatePreview() {
+		const title = $titleInput.val().trim();
+		const description = $descriptionInput.val().trim();
+		const tag = $tagSelect.val();
 
-        if (title || description) {
-            $previewTitle.text(title || 'No title');
-            $previewDescription.text(description || 'No message');
-            $previewTag.text(`Type: ${tag}`);
-            $previewContainer.fadeIn();
-        } else {
-            $previewContainer.fadeOut();
-        }
-    }
+		if (title || description) {
+			$previewTitle.text(title || "No title");
+			$previewDescription.text(description || "No message");
+			$previewTag.text(`Type: ${tag}`);
+			$previewContainer.fadeIn();
+		} else {
+			$previewContainer.fadeOut();
+		}
+	}
 
-    function loadAlertTypes() {
-        frappe.call({
-            method: 'admin_panel.api.admin_api.get_alert_types',
-            callback: function(r) {
-                const topics = r.message && r.message.topics;
-                $tagSelect.empty();
+	function loadAlertTypes() {
+		frappe.call({
+			method: "admin_panel.api.admin_api.get_alert_types",
+			callback: function (r) {
+				const topics = r.message && r.message.topics;
+				$tagSelect.empty();
 
-                if (!topics || topics.length === 0) {
-                    $tagSelect.append('<option value="">No alert types available</option>');
-                    return;
-                }
+				if (!topics || topics.length === 0) {
+					$tagSelect.append('<option value="">No alert types available</option>');
+					return;
+				}
 
-                topics.forEach(function(topic) {
-                    $tagSelect.append(`<option value="${topic}">${topic}</option>`);
-                });
+				topics.forEach(function (topic) {
+					$tagSelect.append(`<option value="${topic}">${topic}</option>`);
+				});
 
-                $tagSelect.prop('disabled', false);
-                $sendButton.prop('disabled', false);
-                updatePreview();
-            },
-            error: function() {
-                $tagSelect.empty().append('<option value="">Failed to load types</option>');
-                frappe.show_alert({
-                    message: 'Could not load alert types from API.',
-                    indicator: 'red'
-                }, 5);
-            }
-        });
-    }
+				$tagSelect.prop("disabled", false);
+				$sendButton.prop("disabled", false);
+				updatePreview();
+			},
+			error: function () {
+				$tagSelect.empty().append('<option value="">Failed to load types</option>');
+				frappe.show_alert(
+					{
+						message: "Could not load alert types from API.",
+						indicator: "red",
+					},
+					5
+				);
+			},
+		});
+	}
 
-    function sendAlert(title, description, alertType) {
-        $sendButton.prop('disabled', true);
-        $sendButton.html('<span class="btn-text">Sending...</span>');
+	function sendAlert(title, description, alertType) {
+		$sendButton.prop("disabled", true);
+		$sendButton.html('<span class="btn-text">Sending...</span>');
 
-        frappe.call({
-            method: 'admin_panel.api.admin_api.send_alert',
-            args: {
-                title: title,
-                message: description,
-                alert_type: alertType
-            },
-            callback: function(response) {
-                if (response.message && response.message.success) {
-                    frappe.show_alert({
-                        message: 'Alert sent successfully to all users!',
-                        indicator: 'green'
-                    }, 5);
+		frappe.call({
+			method: "admin_panel.api.admin_api.send_alert",
+			args: {
+				title: title,
+				message: description,
+				alert_type: alertType,
+			},
+			callback: function (response) {
+				if (response.message && response.message.success) {
+					frappe.show_alert(
+						{
+							message: "Alert sent successfully to all users!",
+							indicator: "green",
+						},
+						5
+					);
 
-                    $titleInput.val('');
-                    $descriptionInput.val('');
-                    $titleCount.text('0');
-                    $descriptionCount.text('0');
-                    $previewContainer.fadeOut();
+					$titleInput.val("");
+					$descriptionInput.val("");
+					$titleCount.text("0");
+					$descriptionCount.text("0");
+					$previewContainer.fadeOut();
 
-                    loadAlertHistory();
-                } else {
-                    const errorMsg = response.message?.error ||
-                                   (response.message?.errors ? response.message.errors.join(', ') : '') ||
-                                   'Unknown error';
+					loadAlertHistory();
+				} else {
+					const errorMsg =
+						response.message?.error ||
+						(response.message?.errors ? response.message.errors.join(", ") : "") ||
+						"Unknown error";
 
-                    frappe.msgprint({
-                        title: 'Error',
-                        message: `Failed to send alert: ${errorMsg}`,
-                        indicator: 'red'
-                    });
-                }
-            },
-            error: function() {
-                frappe.msgprint({
-                    title: 'Error',
-                    message: 'Failed to send alert. Please try again.',
-                    indicator: 'red'
-                });
-            },
-            always: function() {
-                $sendButton.prop('disabled', false);
-                $sendButton.html('<span class="btn-text">Send Alert to All Users</span>');
-            }
-        });
-    }
+					frappe.msgprint({
+						title: "Error",
+						message: `Failed to send alert: ${errorMsg}`,
+						indicator: "red",
+					});
+				}
+			},
+			error: function () {
+				frappe.msgprint({
+					title: "Error",
+					message: "Failed to send alert. Please try again.",
+					indicator: "red",
+				});
+			},
+			always: function () {
+				$sendButton.prop("disabled", false);
+				$sendButton.html('<span class="btn-text">Send Alert to All Users</span>');
+			},
+		});
+	}
 
-    function getSeverityClass(tag) {
-        const t = (tag || '').toUpperCase();
-        if (t.includes('EMERGENCY')) return 'severity-emergency';
-        if (t.includes('ATTENTION'))  return 'severity-attention';
-        if (t.includes('INFO'))       return 'severity-info';
-        if (t.includes('MARKETING'))  return 'severity-marketing';
-        return '';
-    }
+	function getSeverityClass(tag) {
+		const t = (tag || "").toUpperCase();
+		if (t.includes("EMERGENCY")) return "severity-emergency";
+		if (t.includes("ATTENTION")) return "severity-attention";
+		if (t.includes("INFO")) return "severity-info";
+		if (t.includes("MARKETING")) return "severity-marketing";
+		return "";
+	}
 
-    function loadAlertHistory() {
-        frappe.call({
-            method: 'admin_panel.api.admin_api.get_user_alerts',
-            args: { limit: 10 },
-            callback: function(r) {
-                const $historyList = page.main.find('#alert-history-list');
-                $historyList.empty();
+	function loadAlertHistory() {
+		frappe.call({
+			method: "admin_panel.api.admin_api.get_user_alerts",
+			args: { limit: 10 },
+			callback: function (r) {
+				const $historyList = page.main.find("#alert-history-list");
+				$historyList.empty();
 
-                if (!r.message || !r.message.logs || r.message.logs.length === 0) {
-                    $historyList.html('<p style="color:#939998;">No alerts have been sent yet.</p>');
-                    return;
-                }
+				if (!r.message || !r.message.logs || r.message.logs.length === 0) {
+					$historyList.html(
+						'<p style="color:#939998;">No alerts have been sent yet.</p>'
+					);
+					return;
+				}
 
-                const html = r.message.logs.map(log => {
-                    const date = frappe.datetime.str_to_user(log.sent_on);
-                    return `
+				const html = r.message.logs
+					.map((log) => {
+						const date = frappe.datetime.str_to_user(log.sent_on);
+						return `
                         <div class="alert-item ${getSeverityClass(log.tag)}">
                             <h4>${frappe.utils.escape_html(log.title)}</h4>
                             <p>${frappe.utils.escape_html(log.message)}</p>
@@ -409,61 +419,62 @@ frappe.pages['alert-users'].on_page_load = function(wrapper) {
                             </small>
                         </div>
                     `;
-                }).join('');
-                $historyList.html(html);
-            }
-        });
-    }
+					})
+					.join("");
+				$historyList.html(html);
+			},
+		});
+	}
 
-    // Event handlers
-    $titleInput.on('input', function() {
-        $titleCount.text($(this).val().length);
-        updatePreview();
-    });
+	// Event handlers
+	$titleInput.on("input", function () {
+		$titleCount.text($(this).val().length);
+		updatePreview();
+	});
 
-    $descriptionInput.on('input', function() {
-        $descriptionCount.text($(this).val().length);
-        updatePreview();
-    });
+	$descriptionInput.on("input", function () {
+		$descriptionCount.text($(this).val().length);
+		updatePreview();
+	});
 
-    $tagSelect.on('change', updatePreview);
+	$tagSelect.on("change", updatePreview);
 
-    $sendButton.on('click', function() {
-        const title = $titleInput.val().trim();
-        const description = $descriptionInput.val().trim();
-        const alertType = $tagSelect.val();
+	$sendButton.on("click", function () {
+		const title = $titleInput.val().trim();
+		const description = $descriptionInput.val().trim();
+		const alertType = $tagSelect.val();
 
-        if (!title) {
-            frappe.msgprint({
-                title: 'Missing Title',
-                message: 'Please enter an alert title',
-                indicator: 'red'
-            });
-            $titleInput.focus();
-            return;
-        }
+		if (!title) {
+			frappe.msgprint({
+				title: "Missing Title",
+				message: "Please enter an alert title",
+				indicator: "red",
+			});
+			$titleInput.focus();
+			return;
+		}
 
-        if (!description) {
-            frappe.msgprint({
-                title: 'Missing Message',
-                message: 'Please enter an alert message',
-                indicator: 'red'
-            });
-            $descriptionInput.focus();
-            return;
-        }
+		if (!description) {
+			frappe.msgprint({
+				title: "Missing Message",
+				message: "Please enter an alert message",
+				indicator: "red",
+			});
+			$descriptionInput.focus();
+			return;
+		}
 
-        frappe.confirm(
-            `Are you sure you want to send this ${alertType} alert to all users?<br><br>
+		frappe.confirm(
+			`Are you sure you want to send this ${alertType} alert to all users?<br><br>
             <strong>Title:</strong> ${title}<br>
             <strong>Message:</strong> ${description}<br>
             <strong>Type:</strong> ${alertType}`,
-            function() {
-                sendAlert(title, description, alertType);
-            }
-        );
-    });
+			function () {
+				sendAlert(title, description, alertType);
+			}
+		);
+	});
 
-    loadAlertTypes();
-    loadAlertHistory();
-}
+	loadAlertTypes();
+	loadAlertHistory();
+};

--- a/admin_panel/admin_panel/page/alert_users/alert_users.js
+++ b/admin_panel/admin_panel/page/alert_users/alert_users.js
@@ -306,7 +306,7 @@ frappe.pages["alert-users"].on_page_load = function (wrapper) {
 					$descriptionInput.val("");
 					$titleCount.text("0");
 					$descriptionCount.text("0");
-					$previewContainer.fadeOut();
+					updatePreview();
 
 					loadAlertHistory();
 				} else {

--- a/admin_panel/admin_panel/page/alert_users/alert_users.js
+++ b/admin_panel/admin_panel/page/alert_users/alert_users.js
@@ -7,264 +7,212 @@ frappe.pages["alert-users"].on_page_load = function (wrapper) {
 
 	page.main.html(`
         <style>
-            .alert-form-container {
-                max-width: 800px;
-                margin: 40px auto;
-                padding: 30px;
-                background: #FFFFFF;
-                border-radius: 8px;
-                box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            /* ═══ Ops-pulse design system — Alert Users (broadcast compose) ═══
+               Fully scoped: the old block styled global .form-control and leaked
+               into every desk form while this page was in the DOM. */
+            .alert-users-page {
+                --au-surface: var(--card-bg, #ffffff); --au-ink: var(--text-color, #1a2420);
+                --au-ink2: var(--text-muted, #5c6b65); --au-ink3: var(--text-light, #8fa098);
+                --au-line: var(--border-color, #e2e8e5); --au-line-soft: var(--subtle-fg, #ecf1ee);
+                --au-accent: #007856; --au-accent-ink: #007856; --au-accent-soft: #e6f3ee;
+                --au-good: #0ca30c; --au-warn: #b87d00; --au-warn-bg: #fff3d6;
+                --au-serious: #c05a32; --au-serious-bg: #fdeae2;
+                --au-info: #2563eb; --au-info-bg: #e8effd;
+                --au-shadow: 0 1px 2px rgba(26,36,32,0.05), 0 4px 14px rgba(26,36,32,0.04);
+                max-width: 1180px; margin: 0 auto; padding: 8px 12px 40px;
+            }
+            [data-theme="dark"] .alert-users-page, .dark .alert-users-page {
+                --au-accent: #1e9e75; --au-accent-ink: #4cc29e; --au-accent-soft: #12352a;
+                --au-good: #35c135; --au-warn: #fab219; --au-warn-bg: #33290d;
+                --au-serious: #ec835a; --au-serious-bg: #38211a;
+                --au-info: #6ea8fe; --au-info-bg: #172742;
+                --au-shadow: 0 1px 2px rgba(0,0,0,0.35), 0 6px 18px rgba(0,0,0,0.25);
             }
 
-            .alert-form-header {
-                margin-bottom: 30px;
-                padding-bottom: 20px;
-                border-bottom: 2px solid #DDE3E1;
-            }
+            /* compose left, live preview + history right */
+            .alert-users-page .au-grid { display: grid; grid-template-columns: 1fr 400px;
+                gap: 16px; align-items: start; }
+            @media (max-width: 980px) { .alert-users-page .au-grid { grid-template-columns: 1fr; } }
 
-            .alert-form-header h3 {
-                color: #212121;
-                font-weight: 600;
-                margin: 0;
-            }
+            .alert-users-page .au-card { background: var(--au-surface);
+                border: 1px solid var(--au-line); border-radius: 14px;
+                box-shadow: var(--au-shadow); overflow: hidden; }
+            .alert-users-page .au-card + .au-card { margin-top: 16px; }
+            .alert-users-page .au-card-header { padding: 14px 20px 12px;
+                border-bottom: 1px solid var(--au-line); }
+            .alert-users-page .au-card-header h3 { margin: 0; font-size: 15px;
+                font-weight: 650; color: var(--au-ink); letter-spacing: -0.01em; }
+            .alert-users-page .au-card-header p { margin: 3px 0 0; font-size: 12.5px;
+                color: var(--au-ink3); }
+            .alert-users-page .au-card-body { padding: 18px 20px 20px; }
 
-            .alert-form-header p {
-                color: #939998;
-                margin: 8px 0 0 0;
-                font-size: 14px;
-            }
+            /* form */
+            .alert-users-page .form-group { margin-bottom: 18px; }
+            .alert-users-page .form-group label { display: block; font-size: 11px;
+                letter-spacing: 0.05em; text-transform: uppercase; font-weight: 650;
+                color: var(--au-ink2); margin-bottom: 7px; }
+            .alert-users-page .form-group label .required { color: var(--au-serious);
+                margin-left: 2px; }
+            .alert-users-page .form-control { width: 100%; padding: 9px 13px;
+                border: 1px solid var(--au-line); border-radius: 10px; font-size: 13.5px;
+                background: var(--au-surface); color: var(--au-ink); box-sizing: border-box;
+                transition: border-color 0.15s; }
+            .alert-users-page .form-control:focus { outline: 2px solid var(--au-accent);
+                outline-offset: 1px; border-color: var(--au-accent); box-shadow: none; }
+            .alert-users-page .form-control::placeholder { color: var(--au-ink3); }
+            .alert-users-page textarea.form-control { resize: vertical; min-height: 120px;
+                font-family: inherit; }
+            .alert-users-page select.form-control { cursor: pointer; appearance: auto;
+                min-height: 38px; }
+            .alert-users-page .char-count { font-size: 11.5px; color: var(--au-ink3);
+                text-align: right; margin-top: 4px; font-variant-numeric: tabular-nums; }
 
-            .form-group {
-                margin-bottom: 24px;
-            }
+            .alert-users-page .btn-send-alert { width: 100%; margin-top: 4px;
+                background: var(--au-accent); border: 1px solid var(--au-accent);
+                color: #fff; padding: 11px 24px; border-radius: 10px; font-size: 14px;
+                font-weight: 650; cursor: pointer; transition: filter 0.13s; }
+            .alert-users-page .btn-send-alert:hover { filter: brightness(1.07); }
+            .alert-users-page .btn-send-alert:focus-visible { outline: 2px solid var(--au-accent);
+                outline-offset: 2px; }
+            .alert-users-page .btn-send-alert:disabled { opacity: 0.55; cursor: not-allowed; }
 
-            .form-group label {
-                display: block;
-                font-weight: 600;
-                color: #212121;
-                margin-bottom: 8px;
-                font-size: 14px;
-            }
+            /* live preview — styled like the notification the user receives */
+            .alert-users-page .au-preview-empty { padding: 26px 20px; text-align: center;
+                color: var(--au-ink3); font-size: 12.5px; }
+            .alert-users-page .au-alert { border-left: 4px solid var(--au-accent);
+                background: var(--au-line-soft); border-radius: 10px; padding: 13px 16px;
+                margin: 0; }
+            .alert-users-page .au-alert h4 { margin: 0 0 4px; font-size: 14px;
+                font-weight: 650; color: var(--au-ink); overflow-wrap: anywhere; }
+            .alert-users-page .au-alert p { margin: 0; font-size: 13px; color: var(--au-ink2);
+                white-space: pre-wrap; overflow-wrap: anywhere; }
+            .alert-users-page .au-alert-meta { display: flex; gap: 8px; align-items: center;
+                margin-top: 9px; flex-wrap: wrap; }
+            .alert-users-page .au-tag { display: inline-flex; border-radius: 999px;
+                padding: 2px 9px; font-size: 11px; font-weight: 650;
+                background: var(--au-accent-soft); color: var(--au-accent-ink); }
+            .alert-users-page .au-alert-meta small { color: var(--au-ink3); font-size: 11.5px; }
 
-            .form-group label .required {
-                color: #DC2626;
-                margin-left: 2px;
-            }
+            /* severity accents (shared by preview + history) */
+            .alert-users-page .severity-emergency { border-left-color: var(--au-serious); }
+            .alert-users-page .severity-emergency .au-tag { background: var(--au-serious-bg);
+                color: var(--au-serious); }
+            .alert-users-page .severity-attention { border-left-color: var(--au-warn); }
+            .alert-users-page .severity-attention .au-tag { background: var(--au-warn-bg);
+                color: var(--au-warn); }
+            .alert-users-page .severity-info { border-left-color: var(--au-info); }
+            .alert-users-page .severity-info .au-tag { background: var(--au-info-bg);
+                color: var(--au-info); }
+            .alert-users-page .severity-marketing { border-left-color: var(--au-good); }
 
-            .form-control {
-                width: 100%;
-                padding: 12px 16px;
-                border: 1px solid #DDE3E1;
-                border-radius: 6px;
-                font-size: 14px;
-                transition: all 0.3s ease;
-                box-sizing: border-box;
-                background: #FFFFFF;
-                color: #212121;
-            }
+            /* history */
+            .alert-users-page .alert-item { border-left: 4px solid var(--au-accent);
+                background: var(--au-line-soft); padding: 13px 16px; border-radius: 10px;
+                margin-bottom: 12px; }
+            .alert-users-page .alert-item:last-child { margin-bottom: 0; }
+            .alert-users-page .alert-item h4 { margin: 0 0 4px; font-size: 13.5px;
+                font-weight: 650; color: var(--au-ink); overflow-wrap: anywhere; }
+            .alert-users-page .alert-item p { margin: 0; font-size: 12.5px;
+                color: var(--au-ink2); overflow-wrap: anywhere; }
+            .alert-users-page .au-history-empty { color: var(--au-ink3); font-size: 12.5px;
+                margin: 0; }
 
-            .form-control:focus {
-                outline: none;
-                border-color: #007856;
-                box-shadow: 0 0 0 3px rgba(0, 120, 86, 0.1);
-            }
-
-            .form-control::placeholder {
-                color: #939998;
-            }
-
-            textarea.form-control {
-                resize: vertical;
-                min-height: 120px;
-                font-family: inherit;
-            }
-
-            .form-group select {
-                width: 100%;
-                padding: 12px 16px;
-                border: 1px solid #DDE3E1;
-                border-radius: 6px;
-                font-size: 14px;
-                line-height: 1.5;
-                background: #FFFFFF;
-                color: #212121;
-                cursor: pointer;
-                height: auto;
-                min-height: 42px;
-                appearance: none;
-                background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23212121' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
-                background-repeat: no-repeat;
-                background-position: right 12px center;
-                background-size: 16px;
-                padding-right: 40px;
-            }
-
-            .btn-send-alert {
-                background: linear-gradient(135deg, #E8D315 0%, #007856 100%);
-                color: #002118;
-                border: none;
-                padding: 14px 32px;
-                border-radius: 6px;
-                font-size: 15px;
-                font-weight: 600;
-                cursor: pointer;
-                transition: all 0.3s ease;
-                box-shadow: 0 4px 12px rgba(232, 211, 21, 0.3);
-                width: 100%;
-                margin-top: 10px;
-            }
-
-            .btn-send-alert:hover {
-                transform: translateY(-2px);
-                box-shadow: 0 6px 16px rgba(232, 211, 21, 0.4);
-                background: linear-gradient(135deg, #E8D315 20%, #007856 100%);
-            }
-
-            .btn-send-alert:active {
-                transform: translateY(0);
-            }
-
-            .btn-send-alert:disabled {
-                opacity: 0.6;
-                cursor: not-allowed;
-                transform: none;
-            }
-
-            .alert-preview {
-                margin-top: 30px;
-                padding: 20px;
-                background: #F1F1F1;
-                border-radius: 6px;
-                border-left: 4px solid #007856;
-            }
-
-            .alert-preview h4 {
-                color: #212121;
-                margin: 0 0 10px 0;
-                font-size: 16px;
-            }
-
-            .alert-preview p {
-                color: #939998;
-                margin: 0;
-                font-size: 14px;
-            }
-
-            .char-count {
-                font-size: 12px;
-                color: #939998;
-                text-align: right;
-                margin-top: 4px;
-            }
-
-            .alert-history-container {
-            max-width: 800px;
-            margin: 20px auto 60px;
-            padding: 24px;
-            background: #FFFFFF;
-            border-radius: 8px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-            }
-
-            .alert-item {
-                border-left: 4px solid #007856;
-                background: #F9FAF9;
-                padding: 16px 20px;
-                border-radius: 6px;
-                margin-bottom: 14px;
-            }
-
-            .alert-item.severity-emergency { border-left-color: #DC2626; }
-            .alert-item.severity-attention  { border-left-color: #D97706; }
-            .alert-item.severity-info       { border-left-color: #2563EB; }
-            .alert-item.severity-marketing  { border-left-color: #059669; }
-
-            .alert-item h4 {
-                margin: 0 0 6px 0;
-                color: #002118;
-            }
-
-            .alert-item p {
-                margin: 0;
-                color: #555;
-            }
-
-            .alert-item small {
-                color: #888;
-                display: block;
-                margin-top: 6px;
+            @media (prefers-reduced-motion: no-preference) {
+                .alert-users-page .au-card { animation: au-rise 0.3s ease; }
+                @keyframes au-rise { from { opacity: 0; transform: translateY(5px); } }
             }
         </style>
 
-        <div class="alert-form-container">
-            <div class="alert-form-header">
-                <h3>📢 Send Alert to All Users</h3>
-                <p>Create and send an alert message that will be displayed to all users in the system</p>
-            </div>
+        <div class="alert-users-page">
+            <div class="au-grid">
+                <div class="au-card au-compose">
+                    <div class="au-card-header">
+                        <h3>Send Alert to All Users</h3>
+                        <p>The alert is broadcast to every user in the system — you will be asked to confirm.</p>
+                    </div>
+                    <div class="au-card-body">
+                        <div class="form-group">
+                            <label for="alert-title">
+                                Alert Title
+                                <span class="required">*</span>
+                            </label>
+                            <input
+                                type="text"
+                                class="form-control"
+                                id="alert-title"
+                                placeholder="Enter a short, attention-grabbing title"
+                                maxlength="100"
+                            >
+                            <div class="char-count">
+                                <span id="title-count">0</span>/100 characters
+                            </div>
+                        </div>
 
-            <div class="form-group">
-                <label for="alert-title">
-                    Alert Title
-                    <span class="required">*</span>
-                </label>
-                <input
-                    type="text"
-                    class="form-control"
-                    id="alert-title"
-                    placeholder="Enter a short, attention-grabbing title"
-                    maxlength="100"
-                >
-                <div class="char-count">
-                    <span id="title-count">0</span>/100 characters
+                        <div class="form-group">
+                            <label for="alert-description">
+                                Alert Message
+                                <span class="required">*</span>
+                            </label>
+                            <textarea
+                                class="form-control"
+                                id="alert-description"
+                                placeholder="Provide detailed information about the alert..."
+                                maxlength="500"
+                            ></textarea>
+                            <div class="char-count">
+                                <span id="description-count">0</span>/500 characters
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="alert-tag">
+                                Alert Type
+                                <span class="required">*</span>
+                            </label>
+                            <select class="form-control" id="alert-tag" disabled>
+                                <option value="">Loading alert types...</option>
+                            </select>
+                        </div>
+
+                        <button class="btn-send-alert" id="send-alert-btn" disabled>
+                            <span class="btn-text">Send Alert to All Users</span>
+                        </button>
+                    </div>
                 </div>
-            </div>
 
-            <div class="form-group">
-                <label for="alert-description">
-                    Alert Message
-                    <span class="required">*</span>
-                </label>
-                <textarea
-                    class="form-control"
-                    id="alert-description"
-                    placeholder="Provide detailed information about the alert..."
-                    maxlength="500"
-                ></textarea>
-                <div class="char-count">
-                    <span id="description-count">0</span>/500 characters
+                <div class="au-side">
+                    <div class="au-card au-preview-card">
+                        <div class="au-card-header">
+                            <h3>Live Preview</h3>
+                            <p>What users will see</p>
+                        </div>
+                        <div class="au-card-body">
+                            <div class="au-preview-empty">Start typing to see the alert here.</div>
+                            <div id="alert-preview" style="display: none;">
+                                <div class="au-alert alert-preview-card">
+                                    <h4 id="preview-title"></h4>
+                                    <p id="preview-description"></p>
+                                    <div class="au-alert-meta">
+                                        <span class="au-tag" id="preview-tag"></span>
+                                        <small>to all users</small>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="au-card au-history">
+                        <div class="au-card-header">
+                            <h3>Sent Alerts History</h3>
+                            <p>The last 10 broadcasts</p>
+                        </div>
+                        <div class="au-card-body">
+                            <div id="alert-history-list">
+                                <p class="au-history-empty">Loading history...</p>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-            </div>
-
-            <div class="form-group">
-                <label for="alert-tag">
-                    Alert Type
-                    <span class="required">*</span>
-                </label>
-                <select class="form-control" id="alert-tag" disabled>
-                    <option value="">Loading alert types...</option>
-                </select>
-            </div>
-
-            <button class="btn-send-alert" id="send-alert-btn" disabled>
-                <span class="btn-text">Send Alert to All Users</span>
-            </button>
-
-            <div id="alert-preview" style="display: none;">
-                <div class="alert-preview">
-                    <h4>Preview:</h4>
-                    <p><strong id="preview-title"></strong></p>
-                    <p id="preview-description"></p>
-                    <p><small id="preview-tag"></small></p>
-                </div>
-            </div>
-        </div>
-        <div class="alert-history-container">
-            <div class="alert-form-header">
-                <h3>📜 Sent Alerts History</h3>
-                <p>Recently sent alerts will appear here</p>
-            </div>
-            <div id="alert-history-list">
-                <p style="color:#939998;">Loading history...</p>
             </div>
         </div>
     `);
@@ -279,6 +227,8 @@ frappe.pages["alert-users"].on_page_load = function (wrapper) {
 	const $previewTitle = page.main.find("#preview-title");
 	const $previewDescription = page.main.find("#preview-description");
 	const $previewTag = page.main.find("#preview-tag");
+	const $previewEmpty = page.main.find(".au-preview-empty");
+	const $previewCard = page.main.find(".alert-preview-card");
 
 	function updatePreview() {
 		const title = $titleInput.val().trim();
@@ -288,10 +238,13 @@ frappe.pages["alert-users"].on_page_load = function (wrapper) {
 		if (title || description) {
 			$previewTitle.text(title || "No title");
 			$previewDescription.text(description || "No message");
-			$previewTag.text(`Type: ${tag}`);
+			$previewTag.text(tag || "\u2014");
+			$previewCard.attr("class", "au-alert alert-preview-card " + getSeverityClass(tag));
+			$previewEmpty.hide();
 			$previewContainer.fadeIn();
 		} else {
-			$previewContainer.fadeOut();
+			$previewContainer.hide();
+			$previewEmpty.show();
 		}
 	}
 
@@ -402,7 +355,7 @@ frappe.pages["alert-users"].on_page_load = function (wrapper) {
 
 				if (!r.message || !r.message.logs || r.message.logs.length === 0) {
 					$historyList.html(
-						'<p style="color:#939998;">No alerts have been sent yet.</p>'
+						'<p class="au-history-empty">No alerts have been sent yet.</p>'
 					);
 					return;
 				}
@@ -414,9 +367,14 @@ frappe.pages["alert-users"].on_page_load = function (wrapper) {
                         <div class="alert-item ${getSeverityClass(log.tag)}">
                             <h4>${frappe.utils.escape_html(log.title)}</h4>
                             <p>${frappe.utils.escape_html(log.message)}</p>
-                            <small>
-                                🏷️ ${log.tag} &nbsp;&nbsp;👤 ${log.sent_by} &nbsp;&nbsp;🕒 ${date}
-                            </small>
+                            <div class="au-alert-meta">
+                                <span class="au-tag">${frappe.utils.escape_html(
+									log.tag || ""
+								)}</span>
+                                <small>${frappe.utils.escape_html(
+									log.sent_by || ""
+								)} \u00b7 ${date}</small>
+                            </div>
                         </div>
                     `;
 					})

--- a/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
+++ b/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
@@ -117,6 +117,7 @@ class TransferRequestsManager {
 			requestsTable: main.find(".requests-list table"),
 			noRequests: main.find(".no-requests"),
 			requestDetails: main.find(".request-details"),
+			pulseTiles: main.find(".pulse-tiles"),
 			paginationControls: main.find(".pagination-controls"),
 			requestsTbody: main.find(".requests-tbody"),
 			searchLoading: main.find(".search-loading"),
@@ -293,10 +294,45 @@ class TransferRequestsManager {
                 /* pagination */
                 .flash-cashout-manager .pagination-controls { display: flex; }
 
+                /* queue pulse tiles */
+                .flash-cashout-manager .tr-tiles { display: grid;
+                    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+                    gap: 12px; margin-bottom: 14px; }
+                .flash-cashout-manager .tr-tile { background: var(--tr-surface);
+                    border: 1px solid var(--tr-line); border-radius: 14px;
+                    box-shadow: var(--tr-shadow); padding: 12px 16px; }
+                .flash-cashout-manager .tr-tile-label { font-size: 11px; letter-spacing: 0.06em;
+                    text-transform: uppercase; color: var(--tr-ink2); font-weight: 650; }
+                .flash-cashout-manager .tr-tile-value { font-size: 22px; font-weight: 650;
+                    color: var(--tr-ink); font-variant-numeric: tabular-nums; margin-top: 2px; }
+                .flash-cashout-manager .tr-tile-value.warn { color: var(--tr-warn); }
+                .flash-cashout-manager .tr-tile-value.bad { color: var(--tr-serious); }
+                .flash-cashout-manager .tr-tile-sub { font-size: 11.5px; color: var(--tr-ink3);
+                    margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+                /* row age chips */
+                .flash-cashout-manager .tr-age { display: inline-flex; border-radius: 999px;
+                    padding: 2px 8px; font-size: 11px; font-weight: 650; margin-left: 8px;
+                    background: var(--tr-line-soft); color: var(--tr-ink2); }
+                .flash-cashout-manager .tr-age.warn { background: var(--tr-warn-bg); color: var(--tr-warn); }
+                .flash-cashout-manager .tr-age.bad { background: var(--tr-serious-bg); color: var(--tr-serious); }
+
+                /* details as a right drawer — no scroll-jump on row click */
+                .flash-cashout-manager .request-details { position: fixed; top: 0; right: 0;
+                    bottom: 0; width: min(620px, 94vw); z-index: 1040; margin: 0;
+                    border-radius: 16px 0 0 16px; border-right: none;
+                    box-shadow: -20px 0 50px rgba(26, 36, 32, 0.18); overflow-y: auto; }
+                [data-theme="dark"] .flash-cashout-manager .request-details,
+                .dark .flash-cashout-manager .request-details {
+                    box-shadow: -20px 0 50px rgba(0, 0, 0, 0.5); }
+                .flash-cashout-manager .request-details .modern-card-header { position: sticky;
+                    top: 0; background: var(--tr-surface); z-index: 1; }
+
                 @media (prefers-reduced-motion: no-preference) {
-                    .flash-cashout-manager .modern-requests-card,
-                    .flash-cashout-manager .request-details { animation: tr-rise 0.3s ease; }
+                    .flash-cashout-manager .modern-requests-card { animation: tr-rise 0.3s ease; }
                     @keyframes tr-rise { from { opacity: 0; transform: translateY(5px); } }
+                    .flash-cashout-manager .request-details { animation: tr-slide 0.22s ease; }
+                    @keyframes tr-slide { from { opacity: 0.4; transform: translateX(40px); } }
                 }
             </style>
 
@@ -305,6 +341,9 @@ class TransferRequestsManager {
                     <button class="transfer-tab active" data-type="cashout" role="tab" aria-selected="true">Cashouts</button>
                     <button class="transfer-tab" data-type="bridge" role="tab" aria-selected="false">Bridge</button>
                 </div>
+
+                <!-- Queue pulse -->
+                <div class="tr-tiles pulse-tiles" style="display:none;"></div>
 
                 <!-- Search & Filter -->
                 <div class="modern-search-card">
@@ -643,6 +682,12 @@ class TransferRequestsManager {
 		this.$cache.searchInput.on("input", debouncedSearch);
 
 		main.find(".btn-refresh").on("click", () => this.load_requests());
+
+		$(document).on("keydown.transfer_requests", (e) => {
+			if (e.key === "Escape" && !window.cur_dialog) {
+				this.close_details();
+			}
+		});
 		main.find(".btn-close-details").on("click", () => this.close_details());
 		main.on("click", ".btn-create-cashout", () =>
 			this.create_cashout_request(this.selected_request)
@@ -753,7 +798,95 @@ class TransferRequestsManager {
         `);
 	}
 
+	formatAge(dateStr) {
+		const then = new Date(dateStr);
+		if (isNaN(then)) return "";
+		const mins = Math.max(0, Math.floor((Date.now() - then.getTime()) / 60000));
+		if (mins < 60) return `${mins}m`;
+		const hours = Math.floor(mins / 60);
+		if (hours < 24) return `${hours}h`;
+		return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+	}
+
+	age_tone(dateStr) {
+		const then = new Date(dateStr);
+		if (isNaN(then)) return "";
+		const hours = (Date.now() - then.getTime()) / 3600e3;
+		if (hours >= 24) return "bad";
+		if (hours >= 6) return "warn";
+		return "";
+	}
+
+	is_actionable(req) {
+		const status = req.display_status || req.status || "";
+		return (
+			status === CashoutStatus.PENDING ||
+			status === CashoutStatus.DRAFT ||
+			status === CashoutStatus.IN_PROGRESS
+		);
+	}
+
+	render_age_chip(req) {
+		if (!this.is_actionable(req) || !req.creation) return "";
+		const age = this.formatAge(req.creation);
+		if (!age) return "";
+		return `<span class="tr-age ${this.age_tone(req.creation)}">${age}</span>`;
+	}
+
+	load_pulse() {
+		frappe.call({
+			method: "admin_panel.api.pulse.get_transfer_pulse",
+			callback: (res) => {
+				this.pulse = res.message;
+				this.render_pulse();
+			},
+			error: () => this.$cache.pulseTiles.hide(),
+		});
+	}
+
+	render_pulse() {
+		if (!this.pulse) return;
+		const tiles = [];
+		if (this.active_type === "bridge") {
+			const b = this.pulse.bridge || {};
+			tiles.push({ label: "Pending", value: b.pending ?? 0 });
+			tiles.push({ label: "Fiat Received", value: b.fiat_received ?? 0 });
+			tiles.push({
+				label: "Failed",
+				value: b.failed ?? 0,
+				tone: b.failed ? "bad" : "",
+				sub: b.failed ? "needs review" : "none unresolved",
+			});
+		} else {
+			const c = this.pulse.cashouts || {};
+			tiles.push({ label: "Pending", value: c.pending ?? 0 });
+			tiles.push({ label: "In Progress", value: c.in_progress ?? 0 });
+			tiles.push({
+				label: "Oldest Waiting",
+				value: c.oldest_at ? this.formatAge(c.oldest_at) : "\u2014",
+				tone: c.oldest_at ? this.age_tone(c.oldest_at) : "",
+				sub: c.oldest_id || "queue clear",
+			});
+		}
+		this.$cache.pulseTiles.html(
+			tiles
+				.map(
+					(t) => `
+                <div class="tr-tile">
+                    <div class="tr-tile-label">${this.escapeHtml(t.label)}</div>
+                    <div class="tr-tile-value ${t.tone || ""}">${this.escapeHtml(
+						String(t.value)
+					)}</div>
+                    ${t.sub ? `<div class="tr-tile-sub">${this.escapeHtml(t.sub)}</div>` : ""}
+                </div>`
+				)
+				.join("")
+		);
+		this.$cache.pulseTiles.show();
+	}
+
 	load_requests() {
+		this.load_pulse();
 		if (this.active_type === "bridge") {
 			this.load_bridge_requests();
 		} else {
@@ -842,7 +975,7 @@ class TransferRequestsManager {
                 <td><span class="modern-badge ${this.escapeHtml(statusBadge)}">${this.escapeHtml(
 			displayStatus
 		)}</span></td>
-                <td>${this.formatDateTime(req.creation)}</td>
+                <td>${this.formatDateTime(req.creation)}${this.render_age_chip(req)}</td>
                 ${actionsHtml}
             </tr>
         `);
@@ -1162,11 +1295,6 @@ class TransferRequestsManager {
 		completeBtn.toggle(this.canSettleCashout(req));
 
 		panel.show();
-
-		const row = this.page.main.find(`tr[data-request-id="${req.name}"]`);
-		if (row.length) {
-			row[0].scrollIntoView({ behavior: "smooth", block: "start" });
-		}
 	}
 
 	set_cashout_action_buttons_disabled(disabled) {
@@ -1462,11 +1590,6 @@ class TransferRequestsManager {
         `);
 
 		panel.show();
-
-		const row = this.page.main.find(`tr[data-request-id="${this.escapeHtml(req.name)}"]`);
-		if (row.length) {
-			row[0].scrollIntoView({ behavior: "smooth", block: "start" });
-		}
 	}
 
 	close_details() {

--- a/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
+++ b/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
@@ -684,7 +684,9 @@ class TransferRequestsManager {
 		main.find(".btn-refresh").on("click", () => this.load_requests());
 
 		$(document).on("keydown.transfer_requests", (e) => {
-			if (e.key === "Escape" && !window.cur_dialog) {
+			// wrapper visibility guard: desk keeps this page alive after
+			// navigation, and this handler must not fire on other pages
+			if (e.key === "Escape" && !window.cur_dialog && this.page.wrapper.is(":visible")) {
 				this.close_details();
 			}
 		});
@@ -798,10 +800,18 @@ class TransferRequestsManager {
         `);
 	}
 
+	server_now_ms() {
+		// Ages are measured against the server clock the payload ships, not
+		// the browser clock — operator tz must not skew warn/bad tones.
+		const raw = this.pulse && this.pulse.now;
+		const parsed = raw ? new Date(String(raw).replace(" ", "T")).getTime() : NaN;
+		return isNaN(parsed) ? Date.now() : parsed;
+	}
+
 	formatAge(dateStr) {
-		const then = new Date(dateStr);
+		const then = new Date(String(dateStr).replace(" ", "T"));
 		if (isNaN(then)) return "";
-		const mins = Math.max(0, Math.floor((Date.now() - then.getTime()) / 60000));
+		const mins = Math.max(0, Math.floor((this.server_now_ms() - then.getTime()) / 60000));
 		if (mins < 60) return `${mins}m`;
 		const hours = Math.floor(mins / 60);
 		if (hours < 24) return `${hours}h`;
@@ -809,9 +819,9 @@ class TransferRequestsManager {
 	}
 
 	age_tone(dateStr) {
-		const then = new Date(dateStr);
+		const then = new Date(String(dateStr).replace(" ", "T"));
 		if (isNaN(then)) return "";
-		const hours = (Date.now() - then.getTime()) / 3600e3;
+		const hours = (this.server_now_ms() - then.getTime()) / 3600e3;
 		if (hours >= 24) return "bad";
 		if (hours >= 6) return "warn";
 		return "";
@@ -886,6 +896,9 @@ class TransferRequestsManager {
 	}
 
 	load_requests() {
+		// tab switches re-render tiles from the cached pulse immediately —
+		// both datasets are in the payload; the fetch then freshens it
+		if (this.pulse) this.render_pulse();
 		this.load_pulse();
 		if (this.active_type === "bridge") {
 			this.load_bridge_requests();

--- a/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
+++ b/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
@@ -23,7 +23,7 @@ frappe.pages["transfer-requests"].on_page_load = function (wrapper) {
 		single_column: true,
 	});
 
-	new TransferRequestsManager(page);
+	wrapper.transfer_requests = new TransferRequestsManager(page);
 };
 
 const CashoutStatus = {
@@ -133,380 +133,170 @@ class TransferRequestsManager {
 	create_layout() {
 		this.page.main.html(`
             <style>
+                /* ═══ Ops-pulse design system — Transfer Requests (daily queue) ═══
+                   Same tokens as dashboard/census/account-hub; legacy --color-*
+                   names aliased so dynamic templates + inline styles convert. */
                 .flash-cashout-manager {
-                    --color-primary: #007856;
-                    --color-background: #F1F1F1;
-                    --color-layer: #FFFFFF;
-                    --color-text01: #212121;
-                    --color-text02: #939998;
-                    --color-border01: #DDE3E1;
-                    --color-green: #00A700;
-                    --color-error: #DC2626;
-                    --color-warning: #F59E0B;
+                    --tr-surface: var(--card-bg, #ffffff); --tr-ink: var(--text-color, #1a2420);
+                    --tr-ink2: var(--text-muted, #5c6b65); --tr-ink3: var(--text-light, #8fa098);
+                    --tr-line: var(--border-color, #e2e8e5); --tr-line-soft: var(--subtle-fg, #ecf1ee);
+                    --tr-accent: #007856; --tr-accent-ink: #007856; --tr-accent-soft: #e6f3ee;
+                    --tr-good: #0ca30c; --tr-warn: #b87d00; --tr-warn-bg: #fff3d6;
+                    --tr-serious: #c05a32; --tr-serious-bg: #fdeae2;
+                    --tr-shadow: 0 1px 2px rgba(26,36,32,0.05), 0 4px 14px rgba(26,36,32,0.04);
+                    /* legacy aliases */
+                    --color-primary: var(--tr-accent); --color-background: transparent;
+                    --color-layer: var(--tr-surface); --color-text01: var(--tr-ink);
+                    --color-text02: var(--tr-ink2); --color-border01: var(--tr-line);
+                    --color-green: var(--tr-good); --color-error: var(--tr-serious);
+                    --color-warning: var(--tr-warn);
+                    max-width: 1400px; margin: 0 auto;
+                }
+                [data-theme="dark"] .flash-cashout-manager, .dark .flash-cashout-manager {
+                    --tr-accent: #1e9e75; --tr-accent-ink: #4cc29e; --tr-accent-soft: #12352a;
+                    --tr-good: #35c135; --tr-warn: #fab219; --tr-warn-bg: #33290d;
+                    --tr-serious: #ec835a; --tr-serious-bg: #38211a;
+                    --tr-shadow: 0 1px 2px rgba(0,0,0,0.35), 0 6px 18px rgba(0,0,0,0.25);
                 }
 
-                .flash-cashout-manager {
-                    max-width: 1400px;
-                    margin: 0 auto;
-                }
+                /* dataset switch — segmented control */
+                .flash-cashout-manager .transfer-tabs { display: inline-flex; gap: 3px;
+                    background: var(--tr-line-soft); border: 1px solid var(--tr-line);
+                    border-radius: 11px; padding: 3px; margin-bottom: 14px; }
+                .flash-cashout-manager .transfer-tab { border: 0; background: transparent;
+                    color: var(--tr-ink2); font-size: 13px; font-weight: 600;
+                    padding: 6px 18px; border-radius: 8px; cursor: pointer; transition: all 0.13s; }
+                .flash-cashout-manager .transfer-tab:hover { color: var(--tr-ink); }
+                .flash-cashout-manager .transfer-tab.active { background: var(--tr-surface);
+                    color: var(--tr-accent-ink); box-shadow: var(--tr-shadow); }
+                .flash-cashout-manager .transfer-tab:focus-visible { outline: 2px solid var(--tr-accent);
+                    outline-offset: 1px; }
 
-                .flash-cashout-manager .modern-search-card {
-                    background: var(--color-layer);
-                    border-radius: 16px;
-                    padding: 24px;
-                    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-                    border: 1px solid var(--color-border01);
-                    margin-bottom: 24px;
-                }
+                /* toolbar */
+                .flash-cashout-manager .modern-search-card { background: var(--tr-surface);
+                    border: 1px solid var(--tr-line); border-radius: 14px;
+                    box-shadow: var(--tr-shadow); padding: 14px 16px; margin-bottom: 14px; }
+                .flash-cashout-manager .modern-search-wrapper { display: flex; gap: 10px;
+                    flex-wrap: wrap; align-items: center; }
+                .flash-cashout-manager .modern-search-wrapper[style*="margin-bottom"] {
+                    margin-bottom: 10px !important; }
+                .flash-cashout-manager .modern-search-input { flex: 1; min-width: 220px;
+                    padding: 8px 13px; border: 1px solid var(--tr-line); border-radius: 10px;
+                    font-size: 13.5px; background: var(--tr-surface); color: var(--tr-ink); }
+                .flash-cashout-manager .modern-search-input:focus { outline: 2px solid var(--tr-accent);
+                    outline-offset: 1px; border-color: var(--tr-accent); }
+                .flash-cashout-manager .modern-search-input::placeholder { color: var(--tr-ink3); }
+                .flash-cashout-manager .modern-search-select { flex: 0 1 220px; min-width: 170px;
+                    appearance: auto; }
 
-                .flash-cashout-manager .transfer-tabs {
-                    display: inline-flex;
-                    background: var(--color-layer);
-                    border: 1px solid var(--color-border01);
-                    border-radius: 12px;
-                    padding: 4px;
-                    margin-bottom: 16px;
-                    gap: 4px;
-                }
+                /* buttons */
+                .flash-cashout-manager .modern-btn { display: inline-flex; align-items: center;
+                    gap: 6px; border: 1px solid var(--tr-line); background: var(--tr-surface);
+                    color: var(--tr-ink); border-radius: 9px; padding: 7px 14px; font-size: 13px;
+                    font-weight: 600; cursor: pointer; transition: all 0.13s; }
+                .flash-cashout-manager .modern-btn:hover { border-color: var(--tr-accent); }
+                .flash-cashout-manager .modern-btn:focus-visible { outline: 2px solid var(--tr-accent);
+                    outline-offset: 1px; }
+                .flash-cashout-manager .modern-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+                .flash-cashout-manager .modern-btn-primary { background: var(--tr-accent);
+                    border-color: var(--tr-accent); color: #fff; }
+                .flash-cashout-manager .modern-btn-primary:hover { filter: brightness(1.07); }
 
-                .flash-cashout-manager .transfer-tab {
-                    border: 0;
-                    background: transparent;
-                    color: var(--color-text02);
-                    border-radius: 8px;
-                    padding: 10px 18px;
-                    font-size: 14px;
-                    font-weight: 600;
-                    cursor: pointer;
-                }
+                /* quick actions — quiet round icon buttons */
+                .flash-cashout-manager .modern-icon-btn { width: 28px; height: 28px;
+                    display: inline-grid; place-items: center; border-radius: 8px;
+                    border: 1px solid var(--tr-line); background: var(--tr-surface);
+                    color: var(--tr-ink2); cursor: pointer; margin: 0 2px;
+                    font-size: 12px; transition: all 0.13s; }
+                .flash-cashout-manager .modern-icon-btn:hover { border-color: currentColor; }
+                .flash-cashout-manager .modern-icon-btn-primary { color: var(--tr-accent-ink); }
+                .flash-cashout-manager .modern-icon-btn-primary:hover { background: var(--tr-accent-soft); }
+                .flash-cashout-manager .modern-icon-btn-success { color: var(--tr-good); }
+                .flash-cashout-manager .modern-icon-btn-success:hover { background: var(--tr-accent-soft); }
 
-                .flash-cashout-manager .transfer-tab.active {
-                    background: var(--color-primary);
-                    color: white;
-                }
+                /* cards */
+                .flash-cashout-manager .modern-requests-card { background: var(--tr-surface);
+                    border: 1px solid var(--tr-line); border-radius: 14px;
+                    box-shadow: var(--tr-shadow); overflow: hidden; margin-bottom: 14px; }
+                .flash-cashout-manager .modern-card-header { display: flex; align-items: center;
+                    justify-content: space-between; gap: 12px; padding: 13px 18px;
+                    border-bottom: 1px solid var(--tr-line); }
+                .flash-cashout-manager .modern-card-title { margin: 0; font-size: 13.5px;
+                    font-weight: 650; color: var(--tr-ink); display: flex; align-items: center; }
+                .flash-cashout-manager .modern-card-title .fa { color: var(--tr-accent-ink); }
 
-                .flash-cashout-manager .modern-search-wrapper {
-                    display: flex;
-                    gap: 12px;
-                    align-items: center;
-                }
+                /* table */
+                .flash-cashout-manager .modern-table-wrapper { overflow-x: auto; }
+                .flash-cashout-manager .modern-table { width: 100%; border-collapse: collapse;
+                    font-size: 13px; }
+                .flash-cashout-manager .modern-table th { text-align: left; font-size: 11px;
+                    letter-spacing: 0.05em; text-transform: uppercase; color: var(--tr-ink2);
+                    font-weight: 650; padding: 10px 14px; border-bottom: 1px solid var(--tr-line);
+                    white-space: nowrap; }
+                .flash-cashout-manager .modern-table td { padding: 10px 14px;
+                    border-bottom: 1px solid var(--tr-line-soft); color: var(--tr-ink);
+                    font-variant-numeric: tabular-nums; }
+                .flash-cashout-manager .modern-table td strong { font-weight: 600; }
+                .flash-cashout-manager .modern-table tbody tr { cursor: pointer;
+                    border-left: 3px solid transparent; transition: background 0.12s; }
+                .flash-cashout-manager .modern-table tbody tr:hover { background: var(--tr-line-soft); }
+                .flash-cashout-manager .modern-table tbody tr.selected { background: var(--tr-accent-soft);
+                    border-left-color: var(--tr-accent); }
+                .flash-cashout-manager .modern-table tbody tr:last-child td { border-bottom: none; }
 
-                .flash-cashout-manager .modern-search-input {
-                    flex: 1;
-                    max-width: 450px;
-                    padding: 12px 16px;
-                    border: 2px solid var(--color-border01);
-                    border-radius: 12px;
-                    font-size: 15px;
-                    transition: all 0.2s ease;
-                    background: var(--color-layer);
-                    color: var(--color-text01);
-                }
+                /* status chips — pending work is amber, settled is green, failed is serious */
+                .flash-cashout-manager .modern-badge { display: inline-flex; align-items: center;
+                    border-radius: 999px; padding: 3px 11px; font-size: 11.5px; font-weight: 650;
+                    letter-spacing: 0.02em; white-space: nowrap; }
+                .flash-cashout-manager .cashout-badge-pending { background: var(--tr-warn-bg);
+                    color: var(--tr-warn); }
+                .flash-cashout-manager .cashout-badge-paid { background: var(--tr-accent-soft);
+                    color: var(--tr-accent-ink); }
+                .flash-cashout-manager .cashout-badge-cancelled { background: var(--tr-line-soft);
+                    color: var(--tr-ink3); }
+                .flash-cashout-manager .cashout-badge-failed { background: var(--tr-serious-bg);
+                    color: var(--tr-serious); }
 
-                .flash-cashout-manager .modern-search-input:focus {
-                    outline: none;
-                    border-color: var(--color-primary);
-                    box-shadow: 0 0 0 3px rgba(0, 120, 86, 0.1);
-                }
+                /* empty + loading */
+                .flash-cashout-manager .no-requests { text-align: center; padding: 40px 20px; }
+                .flash-cashout-manager .no-requests-icon { font-size: 26px; margin-bottom: 8px;
+                    filter: grayscale(0.4); opacity: 0.75; }
+                .flash-cashout-manager .no-requests-title { color: var(--tr-ink); margin: 0; }
+                .flash-cashout-manager .no-requests-body { color: var(--tr-ink3); margin: 4px 0 0; }
+                .flash-cashout-manager .loading-spinner { text-align: center; padding: 34px 0; }
+                .flash-cashout-manager .loading-spinner p { margin: 8px 0 0; font-size: 12.5px; }
+                .flash-cashout-manager .spinner { width: 22px; height: 22px;
+                    border: 2px solid var(--tr-line); border-top-color: var(--tr-accent);
+                    border-radius: 50%; margin: 0 auto; animation: tr-spin 0.8s linear infinite; }
+                @keyframes tr-spin { to { transform: rotate(360deg); } }
 
-                .flash-cashout-manager .modern-search-input::placeholder {
-                    color: var(--color-text02);
-                }
+                /* detail panel */
+                .flash-cashout-manager .detail-section { margin-bottom: 18px; }
+                .flash-cashout-manager .section-header { font-size: 11px; letter-spacing: 0.06em;
+                    text-transform: uppercase; color: var(--tr-ink2); font-weight: 650;
+                    margin: 0 0 8px; display: flex; align-items: center; }
+                .flash-cashout-manager .detail-item { display: flex; justify-content: space-between;
+                    gap: 12px; align-items: baseline; padding: 6px 0;
+                    border-bottom: 1px solid var(--tr-line-soft); }
+                .flash-cashout-manager .detail-label { font-size: 11px; letter-spacing: 0.05em;
+                    text-transform: uppercase; color: var(--tr-ink2); font-weight: 600; flex: none; }
+                .flash-cashout-manager .detail-value { font-size: 13px; font-weight: 600;
+                    color: var(--tr-ink); text-align: right; word-break: break-word; min-width: 0;
+                    font-variant-numeric: tabular-nums; }
+                .flash-cashout-manager .detail-value.amount-display { font-size: 15px;
+                    font-weight: 650; }
+                .flash-cashout-manager .detail-link { color: var(--tr-accent-ink);
+                    text-decoration: none; font-weight: 600; }
+                .flash-cashout-manager .detail-link:hover { text-decoration: underline; }
+                .flash-cashout-manager .detail-remarks { white-space: pre-wrap; text-align: right; }
 
-                .flash-cashout-manager .modern-search-select {
-                    max-width: 250px;
-                }
+                /* pagination */
+                .flash-cashout-manager .pagination-controls { display: flex; }
 
-                .flash-cashout-manager .modern-btn {
-                    padding: 12px 24px;
-                    border-radius: 12px;
-                    font-weight: 500;
-                    font-size: 15px;
-                    border: none;
-                    cursor: pointer;
-                    transition: all 0.2s ease;
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 8px;
-                }
-
-                .flash-cashout-manager .modern-btn-primary {
-                    background: var(--color-primary);
-                    color: white;
-                }
-
-                .flash-cashout-manager .modern-btn-primary:hover {
-                    background: #005a42;
-                    transform: translateY(-1px);
-                    box-shadow: 0 4px 12px rgba(0, 120, 86, 0.2);
-                }
-
-                .flash-cashout-manager .modern-btn-secondary {
-                    background: var(--color-layer);
-                    color: var(--color-text01);
-                    border: 2px solid var(--color-border01);
-                }
-
-                .flash-cashout-manager .modern-btn-secondary:hover {
-                    background: var(--color-background);
-                    border-color: var(--color-text02);
-                }
-
-                .flash-cashout-manager .modern-icon-btn {
-                    padding: 8px 12px;
-                    border-radius: 8px;
-                    border: none;
-                    cursor: pointer;
-                    transition: all 0.2s ease;
-                    margin: 0 2px;
-                    font-size: 14px;
-                    line-height: 1;
-                }
-
-                .flash-cashout-manager .modern-icon-btn:disabled {
-                    cursor: not-allowed;
-                    opacity: 0.6;
-                }
-
-                .flash-cashout-manager .modern-icon-btn-primary {
-                    background: rgba(0, 120, 86, 0.1);
-                    color: var(--color-primary);
-                }
-
-                .flash-cashout-manager .modern-icon-btn-primary:hover:not(:disabled) {
-                    background: var(--color-primary);
-                    color: white;
-                }
-
-                .flash-cashout-manager .modern-icon-btn-success {
-                    background: rgba(0, 167, 0, 0.1);
-                    color: var(--color-green);
-                }
-
-                .flash-cashout-manager .modern-icon-btn-success:hover:not(:disabled) {
-                    background: var(--color-green);
-                    color: white;
-                }
-
-                .flash-cashout-manager .modern-requests-card {
-                    background: var(--color-layer);
-                    border-radius: 16px;
-                    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-                    border: 1px solid var(--color-border01);
-                    overflow: hidden;
-                    margin-bottom: 24px;
-                }
-
-                .flash-cashout-manager .modern-card-header {
-                    padding: 20px 24px;
-                    background: linear-gradient(135deg, var(--color-primary) 0%, #005a42 100%);
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                }
-
-                .flash-cashout-manager .modern-card-title {
-                    font-size: 20px;
-                    font-weight: 600;
-                    color: white;
-                    margin: 0;
-                }
-
-                .flash-cashout-manager .modern-table-wrapper {
-                    overflow-x: auto;
-                }
-
-                .flash-cashout-manager .modern-table {
-                    width: 100%;
-                    border-collapse: separate;
-                    border-spacing: 0;
-                }
-
-                .flash-cashout-manager .modern-table thead {
-                    background: var(--color-background);
-                }
-
-                .flash-cashout-manager .modern-table th {
-                    padding: 16px 20px;
-                    text-align: left;
-                    font-size: 13px;
-                    font-weight: 600;
-                    color: var(--color-text02);
-                    text-transform: uppercase;
-                    letter-spacing: 0.5px;
-                    border-bottom: 2px solid var(--color-border01);
-                }
-
-                .flash-cashout-manager .modern-table tbody tr {
-                    cursor: pointer;
-                    transition: all 0.2s ease;
-                    border-bottom: 1px solid var(--color-border01);
-                }
-
-                .flash-cashout-manager .modern-table tbody tr:hover {
-                    background: rgba(0, 120, 86, 0.03);
-                }
-
-                .flash-cashout-manager .modern-table tbody tr.selected {
-                    background: rgba(0, 120, 86, 0.15) !important;
-                    border-left: 4px solid var(--color-primary);
-                }
-
-                .flash-cashout-manager .modern-table td {
-                    padding: 16px 20px;
-                    color: var(--color-text01);
-                    font-size: 14px;
-                }
-
-                .flash-cashout-manager .modern-badge {
-                    display: inline-flex;
-                    align-items: center;
-                    padding: 6px 12px;
-                    border-radius: 20px;
-                    font-size: 12px;
-                    font-weight: 600;
-                    text-transform: uppercase;
-                    letter-spacing: 0.5px;
-                }
-
-                .flash-cashout-manager .cashout-badge-pending {
-                    background: rgba(245, 158, 11, 0.15);
-                    color: var(--color-warning);
-                }
-
-                .flash-cashout-manager .cashout-badge-paid {
-                    background: #d4f7d9;
-                    color: #15803d;
-                }
-
-                .flash-cashout-manager .cashout-badge-cancelled {
-                    background: rgba(100, 116, 139, 0.15);
-                    color: #475569;
-                }
-
-                .flash-cashout-manager .cashout-badge-failed {
-                    background: #fde2e2;
-                    color: #b91c1c;
-                }
-
-                .flash-cashout-manager .no-requests {
-                    padding: 60px 20px;
-                    text-align: center;
-                    color: var(--color-text02);
-                }
-
-                .flash-cashout-manager .no-requests-icon {
-                    font-size: 48px;
-                    margin-bottom: 16px;
-                    opacity: 0.3;
-                }
-
-                .flash-cashout-manager .loading-spinner {
-                    padding: 60px 20px;
-                    text-align: center;
-                }
-
-                .flash-cashout-manager .spinner {
-                    width: 40px;
-                    height: 40px;
-                    border: 3px solid var(--color-border01);
-                    border-top-color: var(--color-primary);
-                    border-radius: 50%;
-                    animation: cashout-spin 0.8s linear infinite;
-                    margin: 0 auto 16px;
-                }
-
-                @keyframes cashout-spin {
-                    to { transform: rotate(360deg); }
-                }
-
-                .flash-cashout-manager .section-header {
-                    font-size: 16px;
-                    font-weight: 600;
-                    color: var(--color-text01);
-                    margin-bottom: 16px;
-                    padding-bottom: 12px;
-                    border-bottom: 2px solid var(--color-border01);
-                }
-
-                .flash-cashout-manager .detail-item {
-                    margin-bottom: 16px;
-                    display: flex;
-                    flex-direction: column;
-                    gap: 4px;
-                }
-
-                .flash-cashout-manager .detail-label {
-                    font-size: 12px;
-                    font-weight: 600;
-                    color: var(--color-text02);
-                    text-transform: uppercase;
-                    letter-spacing: 0.5px;
-                }
-
-                .flash-cashout-manager .detail-value {
-                    font-size: 15px;
-                    color: var(--color-text01);
-                    font-weight: 500;
-                }
-
-                .flash-cashout-manager .detail-remarks {
-                    white-space: pre-wrap;
-                }
-
-                .flash-cashout-manager .detail-link {
-                    color: var(--color-primary);
-                    text-decoration: none;
-                    font-weight: 600;
-                }
-
-                .flash-cashout-manager .detail-link:hover {
-                    text-decoration: underline;
-                }
-
-                .flash-cashout-manager .amount-display {
-                    font-size: 20px;
-                    font-weight: 700;
-                    color: var(--color-primary);
-                }
-
-                @media (max-width: 768px) {
-                    .flash-cashout-manager .modern-search-wrapper {
-                        flex-direction: column;
-                        align-items: stretch;
-                    }
-
-                    .flash-cashout-manager .modern-search-input {
-                        max-width: 100%;
-                        width: 100%;
-                    }
-
-                    .flash-cashout-manager .modern-btn {
-                        width: 100%;
-                        justify-content: center;
-                    }
-
-                    .flash-cashout-manager .modern-table th,
-                    .flash-cashout-manager .modern-table td {
-                        padding: 12px 10px;
-                        font-size: 13px;
-                    }
-
-                    .flash-cashout-manager .modern-table-wrapper {
-                        overflow-x: auto;
-                    }
-
-                    .flash-cashout-manager .request-details .card-body {
-                        padding: 16px !important;
-                    }
-
-                    .flash-cashout-manager .request-details .d-flex {
-                        flex-direction: column;
-                    }
-
-                    .flash-cashout-manager .request-details .d-flex button {
-                        width: 100%;
-                    }
+                @media (prefers-reduced-motion: no-preference) {
+                    .flash-cashout-manager .modern-requests-card,
+                    .flash-cashout-manager .request-details { animation: tr-rise 0.3s ease; }
+                    @keyframes tr-rise { from { opacity: 0; transform: translateY(5px); } }
                 }
             </style>
 

--- a/admin_panel/admin_panel/page/wallet_census/wallet_census.js
+++ b/admin_panel/admin_panel/page/wallet_census/wallet_census.js
@@ -115,6 +115,28 @@ const WC_CSS = `
     .wallet-census .alert { border-radius: 12px; border: 1px solid var(--wc-line); padding: 12px 16px; font-size: 13px; }
     .wallet-census .alert-warning { background: var(--wc-warn-bg); color: var(--wc-warn); border-color: transparent; }
     .wallet-census .alert-danger { background: var(--wc-serious-bg); color: var(--wc-serious); border-color: transparent; }
+    .wallet-census .wc-detail-head { display: flex; justify-content: space-between; align-items: center;
+          gap: 10px; margin-bottom: 14px; flex-wrap: wrap; }
+    .wallet-census .wc-kv-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+          gap: 10px; margin: 0 0 18px; }
+    .wallet-census .wc-kv { background: var(--wc-surface); border: 1px solid var(--wc-line);
+          border-radius: 12px; padding: 10px 14px; }
+    .wallet-census .wc-kv .k { font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase;
+          color: var(--wc-ink2); font-weight: 600; margin-bottom: 2px; }
+    .wallet-census .wc-kv .v { font-size: 13.5px; font-weight: 600; color: var(--wc-ink); word-break: break-all; }
+    .wallet-census .wc-kv .v.mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+          font-size: 12px; font-weight: 500; color: var(--wc-ink2); }
+    .wallet-census .wc-chip-st { display: inline-flex; align-items: center; border-radius: 999px;
+          padding: 3px 11px; font-size: 12px; font-weight: 600;
+          background: var(--wc-line-soft); color: var(--wc-ink2); }
+    .wallet-census .wc-chip-st.ok { background: var(--wc-accent-soft); color: var(--wc-accent-ink); }
+    .wallet-census .wc-chip-st.warn { background: var(--wc-warn-bg); color: var(--wc-warn); }
+    .wallet-census .wc-chip-st.bad { background: var(--wc-serious-bg); color: var(--wc-serious); }
+    .wallet-census .wc-amt.in { color: var(--wc-good); font-weight: 650; }
+    .wallet-census .wc-amt.out { color: var(--wc-ink); font-weight: 600; }
+    .wallet-census .wc-fee { color: var(--wc-ink3); font-size: 11.5px; margin-left: 6px; }
+    .wallet-census .wc-defchip { background: var(--wc-accent-soft); color: var(--wc-accent-ink);
+          border-radius: 999px; padding: 2px 9px; font-size: 11px; font-weight: 650; }
     @media (prefers-reduced-motion: no-preference) {
         .wallet-census .wc-rise { opacity: 0; transform: translateY(6px); animation: wc-rise 0.35s ease forwards; }
         @keyframes wc-rise { to { opacity: 1; transform: none; } }
@@ -134,6 +156,16 @@ const BUCKETS = [
 	{ key: "system", label: "System" },
 	{ key: "non_default_wallet", label: "Non-default Wallet" },
 ];
+
+// IBEX transactionTypeId semantics, mapped empirically (2026-07-11) by
+// reconciling full account ledgers against reported balances:
+// 1 & 3 credit the account, 2 & 4 debit it (4 = withdrawal, carries a fee).
+const WC_TX_TYPES = {
+	1: { label: "Credit", dir: "in" },
+	2: { label: "Send", dir: "out" },
+	3: { label: "Credit", dir: "in" },
+	4: { label: "Withdrawal", dir: "out" },
+};
 
 class WalletCensus {
 	constructor(page) {
@@ -522,26 +554,31 @@ class WalletCensus {
 		}
 
 		const i = d.identity;
-		const kv = (label, val) =>
-			`<div class="col-sm-4 mb-2"><div class="text-muted small">${label}</div><div>${
-				val === null || val === undefined || val === ""
-					? "—"
-					: frappe.utils.escape_html(String(val))
-			}</div></div>`;
+		const esc = (v) => frappe.utils.escape_html(String(v == null || v === "" ? "—" : v));
+		const kv = (label, val, mono) =>
+			`<div class="wc-kv"><div class="k">${label}</div><div class="v${
+				mono ? " mono" : ""
+			}">${esc(val)}</div></div>`;
+		const statusChip = (st) => {
+			const cls =
+				{ active: "ok", closed: "bad", locked: "warn" }[(st || "").toLowerCase()] || "";
+			return `<span class="wc-chip-st ${cls}">${esc(st || "unknown")}</span>`;
+		};
 
 		const walletRows = (d.wallets || [])
 			.map(
 				(w) => `<tr>
-                <td>${frappe.utils.escape_html(w.currency || "—")}</td>
-                <td>${frappe.utils.escape_html(w.type || "—")}</td>
-                <td style="text-align:right">${Number(w.live_balance || 0).toLocaleString(
-					undefined,
-					{
-						minimumFractionDigits: 2,
-						maximumFractionDigits: 8,
-					}
-				)}${w.balance_not_found ? ' <span class="text-muted">(drained)</span>' : ""}</td>
-                <td>${w.is_default ? "✓" : ""}</td>
+                <td>${esc(w.currency)}</td>
+                <td>${esc(w.type)}</td>
+                <td style="text-align:right"><span class="wc-amt out">${Number(
+					w.live_balance || 0
+				).toLocaleString(undefined, {
+					minimumFractionDigits: 2,
+					maximumFractionDigits: 8,
+				})}</span>${
+					w.balance_not_found ? '<span class="wc-fee">(drained)</span>' : ""
+				}</td>
+                <td>${w.is_default ? '<span class="wc-defchip">default</span>' : ""}</td>
                 <td><code>${frappe.utils.escape_html(w.wallet_id || "")}</code></td>
             </tr>`
 			)
@@ -551,76 +588,89 @@ class WalletCensus {
 			? d.migrations
 					.map(
 						(m) => `<tr>
-                <td>${frappe.utils.escape_html(m.status || "—")}</td>
-                <td>${frappe.utils.escape_html(m.run_id || "—")}</td>
-                <td>${frappe.utils.escape_html(m.completed_at || m.started_at || "—")}</td>
+                <td>${
+					m.status && m.status.toLowerCase().startsWith("complet")
+						? `<span class="wc-chip-st ok">${esc(m.status)}</span>`
+						: statusChip(m.status)
+				}</td>
+                <td>${esc(m.run_id)}</td>
+                <td>${esc(m.completed_at || m.started_at)}</td>
                 <td>${frappe.utils.escape_html(m.last_error || "")}</td>
             </tr>`
 					)
 					.join("")
-			: '<tr><td colspan="4" class="text-muted">No migration records</td></tr>';
+			: '<tr><td colspan="4" style="color:var(--wc-ink3)">No migration records</td></tr>';
 
 		const txRows = (d.transactions || []).length
 			? d.transactions
-					.map(
-						(t) => `<tr>
-                <td>${frappe.utils.escape_html(t.created_at || "—")}</td>
-                <td style="text-align:right">${
-					t.amount != null && Number.isFinite(Number(t.amount)) ? Number(t.amount) : "—"
-				}</td>
-                <td>${frappe.utils.escape_html(t.currency || "—")}</td>
-                <td>${
-					t.type_id != null && Number.isFinite(Number(t.type_id))
-						? Number(t.type_id)
-						: "—"
-				}</td>
-            </tr>`
-					)
+					.map((t) => {
+						const ty = WC_TX_TYPES[t.type_id] || null;
+						const amt =
+							t.amount != null && Number.isFinite(Number(t.amount))
+								? Number(t.amount).toLocaleString(undefined, {
+										maximumFractionDigits: 8,
+								  })
+								: "—";
+						const sign = ty ? (ty.dir === "in" ? "+" : "−") : "";
+						const fee =
+							t.network_fee && Number(t.network_fee) > 0
+								? `<span class="wc-fee">fee ${Number(t.network_fee).toLocaleString(
+										undefined,
+										{ maximumFractionDigits: 8 }
+								  )}</span>`
+								: "";
+						return `<tr>
+                <td>${esc((t.created_at || "").replace("T", " ").slice(0, 19))}</td>
+                <td style="text-align:right"><span class="wc-amt ${
+					ty ? ty.dir : "out"
+				}">${sign}${amt}</span>${fee}</td>
+                <td>${esc(t.currency)}</td>
+                <td>${ty ? esc(ty.label) : esc(t.type_id)}</td>
+            </tr>`;
+					})
 					.join("")
-			: '<tr><td colspan="4" class="text-muted">No recent transactions</td></tr>';
+			: '<tr><td colspan="4" style="color:var(--wc-ink3)">No recent transactions</td></tr>';
 
 		detail.html(`
-            <div class="d-flex mb-3" style="justify-content:space-between;align-items:center">
+            <div class="wc-detail-head">
                 <div>${backBtn}</div>
-                <div>
-                    <span class="badge badge-info">${frappe.utils.escape_html(
-						i.status || "unknown"
-					)}</span>
-                    <button class="wc-btn" id="wc-hub" style="margin-left:8px">View in Account Hub</button>
+                <div style="display:flex;align-items:center;gap:8px">
+                    ${statusChip(i.status)}
+                    <button class="wc-btn" id="wc-hub">View in Account Hub</button>
                 </div>
             </div>
-            <h4>${frappe.utils.escape_html(i.username || i.account_id || "Customer")}</h4>
-            <div class="row mb-3">
-                ${kv("Username", i.username)}${kv("Phone", i.phone)}${kv("Status", i.status)}
-                ${kv("Level", i.level)}${kv("Role", i.role)}${kv(
-			"Display currency",
-			i.display_currency
-		)}
-                ${kv("Account ID", i.account_id)}${kv("UUID", i.uuid)}${kv(
-			"Created",
-			i.created_at
-		)}
-                ${kv("npub", i.npub)}${kv("Push tokens", d.devices && d.devices.push_tokens)}
+            <h4>${frappe.utils.escape_html(i.username || i.account_id || "Customer")}
+                <span style="font-weight:500;font-size:13px;color:var(--wc-ink3);margin-left:8px">level ${esc(
+					i.level
+				)} · ${esc(i.role)} · created ${esc((i.created_at || "").slice(0, 10))}</span>
+            </h4>
+            <div class="wc-kv-grid">
+                ${kv("Phone", i.phone)}
+                ${kv("Display currency", i.display_currency)}
+                ${kv("Push tokens", d.devices && d.devices.push_tokens)}
                 ${kv("Contacts", (d.contacts || []).length)}
+                ${kv("Account ID", i.account_id, true)}
+                ${kv("UUID", i.uuid, true)}
+                ${kv("npub", i.npub, true)}
             </div>
-            <h5>Wallets <small class="text-muted">(live IBEX balance)</small></h5>
-            <table class="table table-bordered">
-                <thead><tr><th>Currency</th><th>Type</th><th style="text-align:right">Live balance</th><th>Default</th><th>Wallet ID</th></tr></thead>
+            <h5>Wallets <span style="text-transform:none;letter-spacing:0;font-weight:500">— live IBEX balance</span></h5>
+            <table>
+                <thead><tr><th>Currency</th><th>Type</th><th style="text-align:right">Live balance</th><th></th><th>Wallet ID</th></tr></thead>
                 <tbody>${walletRows}</tbody>
             </table>
             <h5>Migration</h5>
-            <table class="table table-bordered">
+            <table>
                 <thead><tr><th>Status</th><th>Run ID</th><th>When</th><th>Error</th></tr></thead>
                 <tbody>${migRows}</tbody>
             </table>
-            <h5>Recent transactions ${
+            <h5>Recent transactions${
 				d.tx_wallet_id
-					? `<small class="text-muted">(${frappe.utils.escape_html(
+					? ` <span style="text-transform:none;letter-spacing:0;font-weight:500">— ${frappe.utils.escape_html(
 							d.tx_wallet_id
-					  )})</small>`
+					  )}</span>`
 					: ""
 			}</h5>
-            <table class="table table-bordered">
+            <table>
                 <thead><tr><th>When</th><th style="text-align:right">Amount</th><th>Currency</th><th>Type</th></tr></thead>
                 <tbody>${txRows}</tbody>
             </table>

--- a/admin_panel/admin_panel/page/wallet_census/wallet_census.js
+++ b/admin_panel/admin_panel/page/wallet_census/wallet_census.js
@@ -99,11 +99,6 @@ const WC_CSS = `
     .wallet-census #wc-detail h4 { font-size: 18px; font-weight: 650; margin: 6px 0 14px; color: var(--wc-ink); }
     .wallet-census #wc-detail h5 { font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase;
           color: var(--wc-ink2); font-weight: 650; margin: 20px 0 8px; }
-    .wallet-census #wc-detail .badge { border-radius: 999px; padding: 3px 11px; font-size: 12px;
-          font-weight: 600; background: var(--wc-accent-soft); color: var(--wc-accent-ink); }
-    .wallet-census #wc-detail .row > div { padding: 8px 12px; }
-    .wallet-census #wc-detail .row .text-muted { font-size: 11px; letter-spacing: 0.05em;
-          text-transform: uppercase; font-weight: 600; }
     .wallet-census #wc-detail table { width: 100%; border-collapse: collapse; font-size: 13px;
           background: var(--wc-surface); border: 1px solid var(--wc-line); border-radius: 12px; overflow: hidden; }
     .wallet-census #wc-detail table th { text-align: left; font-size: 11px; letter-spacing: 0.05em;

--- a/admin_panel/admin_panel/page/wallet_census/wallet_census.js
+++ b/admin_panel/admin_panel/page/wallet_census/wallet_census.js
@@ -39,6 +39,88 @@ function wc_debounce(func, wait) {
 	};
 }
 
+const WC_CSS = `
+    .wallet-census { --wc-surface: var(--card-bg, #ffffff); --wc-ink: var(--text-color, #1a2420);
+          --wc-ink2: var(--text-muted, #5c6b65); --wc-ink3: var(--text-light, #8fa098);
+          --wc-line: var(--border-color, #e2e8e5); --wc-line-soft: var(--subtle-fg, #ecf1ee);
+          --wc-accent: #007856; --wc-accent-ink: #007856; --wc-accent-soft: #e6f3ee;
+          --wc-good: #0ca30c; --wc-warn: #b87d00; --wc-warn-bg: #fff3d6;
+          --wc-serious: #c05a32; --wc-serious-bg: #fdeae2;
+          --wc-shadow: 0 1px 2px rgba(26,36,32,0.05), 0 4px 14px rgba(26,36,32,0.04);
+          max-width: 1240px; margin: 0 auto; }
+    [data-theme="dark"] .wallet-census, .dark .wallet-census {
+          --wc-accent: #1e9e75; --wc-accent-ink: #4cc29e; --wc-accent-soft: #12352a;
+          --wc-good: #35c135; --wc-warn: #fab219; --wc-warn-bg: #33290d;
+          --wc-serious: #ec835a; --wc-serious-bg: #38211a;
+          --wc-shadow: 0 1px 2px rgba(0,0,0,0.35), 0 6px 18px rgba(0,0,0,0.25); }
+    .wallet-census .wc-toolbar { display: flex; align-items: center; gap: 10px; margin-bottom: 16px; flex-wrap: wrap; }
+    .wallet-census .wc-input { border: 1px solid var(--wc-line); border-radius: 9px; padding: 7px 12px;
+          font-size: 13px; background: var(--wc-surface); color: var(--wc-ink); }
+    .wallet-census .wc-input:focus { outline: 2px solid var(--wc-accent); outline-offset: 1px; border-color: var(--wc-accent); }
+    .wallet-census .wc-btn { border: 1px solid var(--wc-line); background: var(--wc-surface); color: var(--wc-ink);
+          border-radius: 9px; padding: 7px 14px; font-size: 13px; font-weight: 600; cursor: pointer;
+          transition: border-color 0.15s; }
+    .wallet-census .wc-btn:hover { border-color: var(--wc-accent); }
+    .wallet-census .wc-btn:focus-visible { outline: 2px solid var(--wc-accent); outline-offset: 1px; }
+    .wallet-census .wc-btn.primary { background: var(--wc-accent); border-color: var(--wc-accent); color: #fff; }
+    .wallet-census .wc-btn.primary:hover { filter: brightness(1.07); }
+    .wallet-census .wc-meta { color: var(--wc-ink2); font-size: 12.5px; margin: 0 0 14px; }
+    .wallet-census .wc-meta .err { color: var(--wc-serious); font-weight: 600; }
+    .wallet-census .wc-tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+          gap: 14px; margin-bottom: 16px; }
+    .wallet-census .wc-tile { background: var(--wc-surface); border: 1px solid var(--wc-line);
+          border-radius: 14px; padding: 15px 17px 12px; box-shadow: var(--wc-shadow);
+          display: flex; flex-direction: column; gap: 5px; min-height: 104px; }
+    .wallet-census .wc-tile-label { font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase;
+          color: var(--wc-ink2); font-weight: 600; }
+    .wallet-census .wc-tile-value { font-size: 27px; font-weight: 650; letter-spacing: -0.015em;
+          line-height: 1.1; color: var(--wc-ink); }
+    .wallet-census .wc-tile-sub { color: var(--wc-ink3); font-size: 12px; margin-top: auto; }
+    .wallet-census .wc-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 14px; }
+    .wallet-census .wc-bucket { border: 1px solid var(--wc-line); background: var(--wc-surface);
+          color: var(--wc-ink2); border-radius: 999px; padding: 5px 13px; font-size: 12.5px;
+          font-weight: 600; cursor: pointer; transition: all 0.12s; }
+    .wallet-census .wc-bucket:hover { border-color: var(--wc-accent); color: var(--wc-ink); }
+    .wallet-census .wc-bucket.active { background: var(--wc-accent); border-color: var(--wc-accent); color: #fff; }
+    .wallet-census .wc-bucket .badge { font-weight: 650; margin-left: 5px; opacity: 0.75; }
+    .wallet-census .wc-card { background: var(--wc-surface); border: 1px solid var(--wc-line);
+          border-radius: 14px; box-shadow: var(--wc-shadow); overflow: hidden; }
+    .wallet-census .wc-count { color: var(--wc-ink3); font-size: 12px; padding: 12px 18px 0; }
+    .wallet-census table.wc-table { width: 100%; border-collapse: collapse; font-size: 13px; margin: 8px 0 0; }
+    .wallet-census table.wc-table th { text-align: left; font-size: 11px; letter-spacing: 0.05em;
+          text-transform: uppercase; color: var(--wc-ink2); font-weight: 650; padding: 10px 18px;
+          border-bottom: 1px solid var(--wc-line); white-space: nowrap; cursor: pointer; }
+    .wallet-census table.wc-table td { padding: 9px 18px; border-bottom: 1px solid var(--wc-line-soft);
+          color: var(--wc-ink); font-variant-numeric: tabular-nums; }
+    .wallet-census table.wc-table tr:last-child td { border-bottom: none; }
+    .wallet-census .wc-row:hover { background: var(--wc-line-soft); }
+    .wallet-census table.wc-table code { background: transparent; color: var(--wc-ink3); font-size: 12px; }
+    .wallet-census .wc-morebar { padding: 12px 18px 14px; display: flex; gap: 10px; }
+    .wallet-census #wc-detail h4 { font-size: 18px; font-weight: 650; margin: 6px 0 14px; color: var(--wc-ink); }
+    .wallet-census #wc-detail h5 { font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase;
+          color: var(--wc-ink2); font-weight: 650; margin: 20px 0 8px; }
+    .wallet-census #wc-detail .badge { border-radius: 999px; padding: 3px 11px; font-size: 12px;
+          font-weight: 600; background: var(--wc-accent-soft); color: var(--wc-accent-ink); }
+    .wallet-census #wc-detail .row > div { padding: 8px 12px; }
+    .wallet-census #wc-detail .row .text-muted { font-size: 11px; letter-spacing: 0.05em;
+          text-transform: uppercase; font-weight: 600; }
+    .wallet-census #wc-detail table { width: 100%; border-collapse: collapse; font-size: 13px;
+          background: var(--wc-surface); border: 1px solid var(--wc-line); border-radius: 12px; overflow: hidden; }
+    .wallet-census #wc-detail table th { text-align: left; font-size: 11px; letter-spacing: 0.05em;
+          text-transform: uppercase; color: var(--wc-ink2); font-weight: 650; padding: 9px 14px;
+          border-bottom: 1px solid var(--wc-line); background: var(--wc-line-soft); }
+    .wallet-census #wc-detail table td { padding: 8px 14px; border-bottom: 1px solid var(--wc-line-soft);
+          font-variant-numeric: tabular-nums; }
+    .wallet-census #wc-detail table tr:last-child td { border-bottom: none; }
+    .wallet-census .alert { border-radius: 12px; border: 1px solid var(--wc-line); padding: 12px 16px; font-size: 13px; }
+    .wallet-census .alert-warning { background: var(--wc-warn-bg); color: var(--wc-warn); border-color: transparent; }
+    .wallet-census .alert-danger { background: var(--wc-serious-bg); color: var(--wc-serious); border-color: transparent; }
+    @media (prefers-reduced-motion: no-preference) {
+        .wallet-census .wc-rise { opacity: 0; transform: translateY(6px); animation: wc-rise 0.35s ease forwards; }
+        @keyframes wc-rise { to { opacity: 1; transform: none; } }
+    }
+`;
+
 const WC_PAGE_SIZE = 200;
 const WC_PAGE_STEP = 500;
 
@@ -77,23 +159,24 @@ class WalletCensus {
 
 	render_shell() {
 		this.page.main.html(`
+            <style>${WC_CSS}</style>
             <div class="wallet-census">
-                <div class="mb-3">
-                    <input type="text" id="wc-lookup" class="form-control" style="max-width:360px;display:inline-block"
+                <div class="wc-toolbar">
+                    <input type="text" id="wc-lookup" class="wc-input" style="min-width:320px;flex:1;max-width:420px"
                         placeholder="Look up a customer: username / phone / accountId…">
-                    <button class="btn btn-primary btn-sm ml-2" id="wc-lookup-btn">Look up</button>
+                    <button class="wc-btn primary" id="wc-lookup-btn">Look up</button>
                 </div>
                 <div id="wc-detail" style="display:none"></div>
                 <div id="wc-census">
-                    <div id="wc-status" class="text-muted small mb-3"></div>
-                    <div id="wc-summary" class="row mb-3"></div>
-                    <div id="wc-buckets" class="mb-2"></div>
-                    <div class="mb-2">
-                        <input type="text" id="wc-search" class="form-control" style="max-width:320px;display:inline-block"
+                    <div id="wc-status" class="wc-meta"></div>
+                    <div id="wc-summary" class="wc-tiles"></div>
+                    <div id="wc-buckets" class="wc-chips"></div>
+                    <div class="wc-toolbar">
+                        <input type="text" id="wc-search" class="wc-input" style="min-width:280px"
                             placeholder="Filter loaded rows by username / accountId…">
-                        <button class="btn btn-default btn-sm ml-2" id="wc-export">Export CSV</button>
+                        <button class="wc-btn" id="wc-export">Export CSV</button>
                     </div>
-                    <div id="wc-table" class="table-responsive"></div>
+                    <div id="wc-table"></div>
                 </div>
             </div>
         `);
@@ -175,7 +258,7 @@ class WalletCensus {
 			);
 		} else if (s.status === "Failed") {
 			this.set_status(
-				`<span class="text-danger">Last run failed: ${frappe.utils.escape_html(
+				`<span class="err">Last run failed: ${frappe.utils.escape_html(
 					s.error || ""
 				)}</span>`
 			);
@@ -215,12 +298,10 @@ class WalletCensus {
 			usdt = t.usdt || {},
 			btc = t.btc || {};
 		const card = (title, value, sub) => `
-            <div class="col-sm-3">
-                <div class="card p-3 mb-2">
-                    <div class="text-muted small">${title}</div>
-                    <div style="font-size:1.4rem;font-weight:600">${value}</div>
-                    <div class="text-muted small">${sub || ""}</div>
-                </div>
+            <div class="wc-tile wc-rise">
+                <div class="wc-tile-label">${title}</div>
+                <div class="wc-tile-value">${value}</div>
+                <div class="wc-tile-sub">${sub || ""}</div>
             </div>`;
 		this.page.main
 			.find("#wc-summary")
@@ -248,8 +329,8 @@ class WalletCensus {
 		const html = BUCKETS.map((b) => {
 			const count =
 				b.key === "all" ? this.totals.accounts || 0 : this.bucket_counts[b.key] || 0;
-			const active = b.key === this.active_bucket ? "btn-primary" : "btn-default";
-			return `<button class="btn btn-sm ${active} mr-1 mb-1 wc-bucket" data-bucket="${b.key}">${b.label} <span class="badge">${count}</span></button>`;
+			const active = b.key === this.active_bucket ? " active" : "";
+			return `<button class="wc-bucket${active}" data-bucket="${b.key}">${b.label} <span class="badge">${count}</span></button>`;
 		}).join("");
 		const el = this.page.main.find("#wc-buckets");
 		el.html(html);
@@ -329,22 +410,24 @@ class WalletCensus {
 			.join("");
 		const moreBtns =
 			rows.length > visible.length
-				? `<div class="mb-2">
-                    <button class="btn btn-default btn-sm" id="wc-more">Show ${WC_PAGE_STEP} more</button>
-                    <button class="btn btn-default btn-sm ml-2" id="wc-all">Show all</button>
+				? `<div class="wc-morebar">
+                    <button class="wc-btn" id="wc-more">Show ${WC_PAGE_STEP} more</button>
+                    <button class="wc-btn" id="wc-all">Show all</button>
                 </div>`
 				: "";
 		this.page.main.find("#wc-table").html(`
-            <div class="text-muted small mb-1">Showing ${visible.length} of ${
-			rows.length
-		} accounts</div>
-            <table class="table table-bordered table-hover">
-                <thead><tr>${head}</tr></thead>
-                <tbody>${
-					body ||
-					'<tr><td colspan="6" class="text-center text-muted">No accounts</td></tr>'
-				}</tbody>
-            </table>${moreBtns}`);
+            <div class="wc-card wc-rise">
+                <div class="wc-count">Showing ${visible.length} of ${rows.length} accounts</div>
+                <div style="overflow-x:auto">
+                    <table class="wc-table">
+                        <thead><tr>${head}</tr></thead>
+                        <tbody>${
+							body ||
+							'<tr><td colspan="6" style="text-align:center;color:var(--wc-ink3)">No accounts</td></tr>'
+						}</tbody>
+                    </table>
+                </div>${moreBtns}
+            </div>`);
 		this.page.main.find(".wc-sort").on("click", (e) => {
 			const key = e.currentTarget.dataset.key;
 			if (this.sort_key === key) this.sort_dir = this.sort_dir === "desc" ? "asc" : "desc";
@@ -378,7 +461,7 @@ class WalletCensus {
 			args: { query: query },
 			callback: (res) => this.render_detail(res.message || {}, query),
 			error: () => {
-				const backBtn = `<button class="btn btn-default btn-sm" id="wc-back">← Back to census</button>`;
+				const backBtn = `<button class="wc-btn" id="wc-back">← Back to census</button>`;
 				detail.html(
 					`<div class="mb-2">${backBtn}</div>
                      <div class="alert alert-danger">Failed to load customer — the server returned an error. Check logs or try again.</div>`
@@ -395,7 +478,7 @@ class WalletCensus {
 
 	render_detail(d, query) {
 		const detail = this.page.main.find("#wc-detail");
-		const backBtn = `<button class="btn btn-default btn-sm" id="wc-back">← Back to census</button>`;
+		const backBtn = `<button class="wc-btn" id="wc-back">← Back to census</button>`;
 		if (!d.found) {
 			// The census row may still carry IBEX-side facts even when the DB has no match.
 			const row = (this.rows || []).find(
@@ -503,7 +586,7 @@ class WalletCensus {
                     <span class="badge badge-info">${frappe.utils.escape_html(
 						i.status || "unknown"
 					)}</span>
-                    <button class="btn btn-default btn-sm ml-2" id="wc-hub">View in Account Hub</button>
+                    <button class="wc-btn" id="wc-hub" style="margin-left:8px">View in Account Hub</button>
                 </div>
             </div>
             <h4>${frappe.utils.escape_html(i.username || i.account_id || "Customer")}</h4>

--- a/admin_panel/api/pulse.py
+++ b/admin_panel/api/pulse.py
@@ -148,6 +148,9 @@ def get_upgrade_pulse():
 	week_ago = frappe.utils.add_days(frappe.utils.now_datetime(), -7)
 	return {
 		"pending": frappe.db.count("Account Upgrade Request", {"status": "Pending"}),
+		# Approximation: `modified` bumps on ANY re-save of an already
+		# processed request (e.g. phone sync), not just the approve/reject
+		# transition — the doctype records no processed-at timestamp.
 		"processed_week": frappe.db.count(
 			"Account Upgrade Request",
 			{"status": ["in", ["Approved", "Rejected"]], "modified": [">=", week_ago]},

--- a/admin_panel/api/pulse.py
+++ b/admin_panel/api/pulse.py
@@ -131,3 +131,28 @@ def get_transfer_pulse():
 		"bridge": bridge_counts,
 		"now": str(frappe.utils.now_datetime()),
 	}
+
+
+@frappe.whitelist()
+@require_admin()
+@handle_api_errors
+def get_upgrade_pulse():
+	"""Queue vitals for the Account Management (upgrade requests) tiles."""
+	oldest = frappe.get_all(
+		"Account Upgrade Request",
+		filters={"status": "Pending"},
+		fields=["name", "username", "creation"],
+		order_by="creation asc",
+		limit=1,
+	)
+	week_ago = frappe.utils.add_days(frappe.utils.now_datetime(), -7)
+	return {
+		"pending": frappe.db.count("Account Upgrade Request", {"status": "Pending"}),
+		"processed_week": frappe.db.count(
+			"Account Upgrade Request",
+			{"status": ["in", ["Approved", "Rejected"]], "modified": [">=", week_ago]},
+		),
+		"oldest_at": str(oldest[0].creation) if oldest else None,
+		"oldest_who": (oldest[0].username or oldest[0].name) if oldest else None,
+		"now": str(frappe.utils.now_datetime()),
+	}

--- a/admin_panel/api/pulse.py
+++ b/admin_panel/api/pulse.py
@@ -95,3 +95,39 @@ def get_dashboard_pulse():
 		"upgrades": upgrades,
 		"now": str(frappe.utils.now_datetime()),
 	}
+
+
+@frappe.whitelist()
+@require_admin()
+@handle_api_errors
+def get_transfer_pulse():
+	"""Queue vitals for the Transfer Requests page tiles.
+
+	Counts are DB-wide (not the current table page/filter) so the tiles
+	stay honest under pagination and status filters.
+	"""
+	oldest = frappe.get_all(
+		"Cashout",
+		filters={"status": ["in", ACTIONABLE_CASHOUT_STATUSES]},
+		fields=["name", "creation"],
+		order_by="creation asc",
+		limit=1,
+	)
+	bridge_counts = {
+		key: frappe.db.count("Bridge Transfer Request", {"status": status})
+		for key, status in (
+			("pending", "Pending"),
+			("fiat_received", "Fiat Received"),
+			("failed", "Failed"),
+		)
+	}
+	return {
+		"cashouts": {
+			"pending": frappe.db.count("Cashout", {"status": "Pending"}),
+			"in_progress": frappe.db.count("Cashout", {"status": "In Progress"}),
+			"oldest_at": str(oldest[0].creation) if oldest else None,
+			"oldest_id": oldest[0].name if oldest else None,
+		},
+		"bridge": bridge_counts,
+		"now": str(frappe.utils.now_datetime()),
+	}

--- a/admin_panel/tests/test_pulse_page_contract.py
+++ b/admin_panel/tests/test_pulse_page_contract.py
@@ -1,0 +1,75 @@
+"""Contract tests for the ops-pulse page instrumentation.
+
+Text-level assertions in the repo's established style: they pin the
+invariants the ops-pulse rollout introduced — endpoint gating, page
+wiring, the desk-SPA Escape-handler guards, server-clock age math, and
+CSS scoping (the pre-rollout blocks declared GLOBAL selectors that bled
+into every desk page).
+"""
+
+import re
+from pathlib import Path
+
+ADMIN_PANEL = Path(__file__).resolve().parents[1]
+PAGES = ADMIN_PANEL / "admin_panel" / "page"
+
+
+def read(path):
+	return path.read_text()
+
+
+PULSE_PY = read(ADMIN_PANEL / "api" / "pulse.py")
+TRANSFER_JS = read(PAGES / "transfer_requests" / "transfer_requests.js")
+MGMT_JS = read(PAGES / "account_management" / "account_management.js")
+ALERT_JS = read(PAGES / "alert_users" / "alert_users.js")
+
+
+def test_pulse_endpoints_are_whitelisted_and_admin_gated():
+	"""Every pulse endpoint carries the full decorator stack, in order —
+	whitelist alone would expose queue metrics to any logged-in user."""
+	for fn in ("get_dashboard_pulse", "get_transfer_pulse", "get_upgrade_pulse"):
+		stack = f"@frappe.whitelist()\n@require_admin()\n@handle_api_errors\ndef {fn}("
+		assert stack in PULSE_PY, f"{fn} is missing the whitelist/require_admin/handle_api_errors stack"
+
+
+def test_pages_wire_their_pulse_endpoints():
+	assert 'method: "admin_panel.api.pulse.get_transfer_pulse"' in TRANSFER_JS
+	assert 'method: "admin_panel.api.pulse.get_upgrade_pulse"' in MGMT_JS
+
+
+def test_drawer_escape_handlers_guard_dialog_and_page_visibility():
+	"""Desk keeps page wrappers alive after navigation; a document-level
+	Escape handler without both guards closes drawers on OTHER pages."""
+	for js in (TRANSFER_JS, MGMT_JS):
+		handler = re.search(r"keydown\.[a-z_]+\", \(e\) => \{(?P<body>.*?)\n\t\t\}\);", js, re.DOTALL)
+		assert handler, "expected a namespaced document keydown handler"
+		body = handler.group("body")
+		assert "window.cur_dialog" in body
+		assert 'this.page.wrapper.is(":visible")' in body
+
+
+def test_age_math_uses_server_clock_and_iso_safe_parsing():
+	"""frappe datetimes are space-separated (implementation-defined in
+	new Date(); Invalid Date on WebKit) and server-local — ages must be
+	computed from the payload's `now`, parsed with the T-separator."""
+	for js in (TRANSFER_JS, MGMT_JS):
+		assert "server_now_ms()" in js
+		assert 'replace(" ", "T")' in js
+		assert re.search(
+			r"formatAge\(dateStr\) \{\n\t\tconst then = new Date\(String\(dateStr\)\.replace", js
+		)
+
+
+def test_page_css_stays_scoped():
+	"""The pre-rollout blocks styled global .form-control / .modern-*
+	selectors, restyling every desk form while the page was in the DOM.
+	All rules must lead with the page's scope class."""
+	for js, scope in (
+		(ALERT_JS, ".alert-users-page"),
+		(MGMT_JS, ".flash-account-manager"),
+		(TRANSFER_JS, ".flash-cashout-manager"),
+	):
+		css = js[js.index("<style>") : js.index("</style>")]
+		leaks = re.findall(r"\n\s+(\.(?:form-control|modern-[a-z-]+)[^\n{]*)\{", css)
+		assert not leaks, f"unscoped selectors in {scope} page CSS: {leaks}"
+		assert scope in css, f"expected {scope}-scoped rules"

--- a/admin_panel/tests/test_transfer_requests_page_contract.py
+++ b/admin_panel/tests/test_transfer_requests_page_contract.py
@@ -44,7 +44,7 @@ def test_transfer_requests_page_fixture_replaces_cashout_requests_page():
 def test_transfer_requests_js_registers_page_and_bridge_tab():
 	js = read_text(PAGE_DIR / "transfer_requests.js")
 
-	assert "frappe.pages['transfer-requests']" in js
+	assert 'frappe.pages["transfer-requests"]' in js
 	assert "TransferRequestsManager" in js
 	assert "Cashouts" in js
 	assert "Bridge" in js
@@ -84,13 +84,13 @@ def test_transfer_requests_cashout_tab_has_account_management_style_action_butto
 	js = read_text(PAGE_DIR / "transfer_requests.js")
 
 	assert "create_request_row(req, showActions = true)" in js
-	assert "'Actions'" in js
+	assert '"Actions"' in js
 	assert "modern-icon-btn" in js
 	assert "btn-quick-create" in js
 	assert "btn-quick-confirm" in js
 	assert "btn-quick-complete" in js
 	assert "e.stopPropagation()" in js
-	assert "closest('button')" in js
+	assert 'closest("button")' in js
 	assert "create_cashout_request(req)" in js
 	assert "confirm_cashout_payment(req)" in js
 	assert "complete_cashout(req)" in js
@@ -101,8 +101,8 @@ def test_transfer_requests_bridge_tab_stays_read_only_without_actions_column():
 
 	assert "const cashoutHeaders" in js
 	assert "const bridgeHeaders" in js
-	assert "const headers = this.active_type === 'bridge' ? bridgeHeaders : cashoutHeaders" in js
-	assert "const bridgeHeaders = ['Request ID', 'Type', 'Amount', 'Status', 'Failure', 'Last Seen']" in js
+	assert 'const headers = this.active_type === "bridge" ? bridgeHeaders : cashoutHeaders' in js
+	assert 'const bridgeHeaders = ["Request ID", "Type", "Amount", "Status", "Failure", "Last Seen"]' in js
 
 
 def test_admin_api_exposes_cashout_action_endpoints():
@@ -141,7 +141,7 @@ def test_cashout_payment_bank_entry_sets_required_reference_fields():
 	cashout_py = read_text(ADMIN_PANEL / "admin_panel" / "doctype" / "cashout" / "cashout.py")
 
 	assert "def create_payment_journal_entry(self, reference_no=None, reference_date=None)" in cashout_py
-	assert "payment_reference_no = (reference_no or self.transaction_id or self.name)" in cashout_py
+	assert "payment_reference_no = reference_no or self.transaction_id or self.name" in cashout_py
 	assert '"cheque_no": payment_reference_no' in cashout_py
 	assert '"cheque_date": payment_reference_date' in cashout_py
 	assert "doc.create_payment_journal_entry(reference_no=confirmation_code" in api_py
@@ -153,4 +153,4 @@ def test_cashout_details_render_remarks_from_cashout_record():
 
 	assert '<span class="detail-label">Remarks</span>' in js
 	assert "detail-remarks" in js
-	assert "panel.find('.detail-remarks').text(req.remarks || '-')" in js
+	assert 'panel.find(".detail-remarks").text(req.remarks || "-")' in js


### PR DESCRIPTION
Extends the v1.9.0 dashboard design system to **every remaining desk page**, and gives the two work-queue pages the same operational instrumentation the dashboard introduced. Net **−177 lines** while adding features.

## Per-page

| Page | Restyle | Layout / features |
|------|---------|-------------------|
| Wallet Census (list + detail) | ops-pulse tokens, chips, tables | tx-type labels (Credit/Send/Withdrawal), signed amounts, kv detail anatomy |
| Account Hub | full token system, legacy `--color-*` aliased | **identity band**: username + level/status chips, phone · email · joined meta, per-wallet balance chips; account actions moved to the header; status dots in the search rail |
| Transfer Requests | same treatment, segmented Cashouts/Bridge switch | **pulse tiles** (Pending / In Progress / Oldest Waiting; Bridge: Pending / Fiat Received / Failed), **age chips** on actionable rows (amber ≥6h, red ≥24h), **details drawer** (fixed right panel, Esc closes, no scroll-jump) |
| Account Management | scoped redesign | same tiles/chips/drawer; level-chip intensity ramp (Trial → Merchant solid); Reject demoted to outline; rejection reason as serious notes-box |
| Alert Users | scoped redesign, dark mode added | **two-pane compose**: live preview rendered as the actual alert card, severity re-tones as you switch Alert Type; history with severity edges |

## Real bugs fixed along the way

- **Global CSS bleed**: `account_management` and `alert_users` declared unscoped `.modern-*` and `.form-control` rules that restyled other desk pages (including core form controls) whenever those pages were in the DOM. All page CSS is now scoped to its page root.
- **Double popup on cashout completion**: stray `frappe.msgprint` in `cashout.py` on top of the page's own toast (a contract test already banned it; the removal never landed).
- **5 stale contract tests** failing on formatter drift (pre-prettier quoting / pre-ruff parens) — assertions updated to the formatted code.

## New backend

`api/pulse.py` gains `get_transfer_pulse` and `get_upgrade_pulse` — DB-wide queue counts (honest under pagination/filters), same `whitelist + require_admin + handle_api_errors` stack as `get_dashboard_pulse`, refreshed on every table load.

## Adversarial review (multi-agent) + fixes

A 25-agent review pass (6 dimensions, refute-first verification per finding) confirmed 14 findings; all applied in `ed79fd7`:

- status dots were dead code (Title Case vs UPPERCASE key mismatch) — fixed + extended to account search results
- two document-level Escape handlers leaked across the desk SPA — now guarded on wrapper visibility
- age math used the browser clock with non-ISO `Date` parsing (Invalid Date on WebKit; operator-tz skewed warn/red tones) — now measured against the payload's server `now` with T-separator parsing
- stale tiles on tab switch; alert preview blank after send; sticky rail under the navbar; dead census rules; `processed_week` approximation documented

## Tests

New `test_pulse_page_contract.py` (5 tests): pulse endpoint decorator stack, page→endpoint wiring, both Esc-handler guards, server-clock age math, and a **CSS-scoping guard** that fails if global `.form-control`/`.modern-*` selectors ever return. Suite: **44 passed**; the 3 remaining failures are the pre-existing stale `test_account_hub_search_js` tests (implement-or-delete decision tracked separately).

## Verification

Every page verified live (light + dark, all tabs/drawers/dialogs) on the local bench against seeded data; pulse endpoints exercised against the real backend. Review-pass fixes each re-verified in-browser (dot tones, sticky offset, server-clock ages, Esc guard both directions, preview restore).

## Deploy notes

- Page JS is redis-cached: run `bench clear-cache` after the image bump (migrate job does not clear it).
- `pulse.py` adds endpoints — normal pod restart on deploy covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
