### PR TITLE
feat: Bank Account Update Request DocType + approval endpoints [ENG-509]

### DIFF
--- a/admin_panel/admin_panel/doctype/bank_account_update_request/bank_account_update_request.json
+++ b/admin_panel/admin_panel/doctype/bank_account_update_request/bank_account_update_request.json
@@ -1,0 +1,120 @@
+{
+	"actions": [],
+	"allow_rename": 1,
+	"creation": "2026-07-13 00:00:00.000000",
+	"custom": 0,
+	"default_view": "List",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"party",
+		"bank_account",
+		"status",
+		"support_note",
+		"new_details_section",
+		"bank_name",
+		"bank_branch",
+		"account_type",
+		"account_number",
+		"currency"
+	],
+	"fields": [
+		{
+			"fieldname": "party",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"label": "Customer",
+			"options": "Customer",
+			"reqd": 1
+		},
+		{
+			"fieldname": "bank_account",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"label": "Bank Account",
+			"options": "Bank Account",
+			"reqd": 1
+		},
+		{
+			"default": "Pending",
+			"fieldname": "status",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"label": "Status",
+			"options": "Pending\nApproved\nRejected\nClosed"
+		},
+		{
+			"fieldname": "support_note",
+			"fieldtype": "Small Text",
+			"label": "Support Note"
+		},
+		{
+			"fieldname": "new_details_section",
+			"fieldtype": "Section Break",
+			"label": "Requested New Details"
+		},
+		{
+			"fieldname": "bank_name",
+			"fieldtype": "Data",
+			"label": "Bank Name"
+		},
+		{
+			"fieldname": "bank_branch",
+			"fieldtype": "Data",
+			"label": "Bank Branch"
+		},
+		{
+			"fieldname": "account_type",
+			"fieldtype": "Link",
+			"label": "Account Type",
+			"options": "Bank Account Type"
+		},
+		{
+			"fieldname": "account_number",
+			"fieldtype": "Data",
+			"label": "Account Number"
+		},
+		{
+			"fieldname": "currency",
+			"fieldtype": "Link",
+			"label": "Currency",
+			"options": "Currency"
+		}
+	],
+	"index_web_pages_for_search": 1,
+	"links": [],
+	"modified": "2026-07-13 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "Admin Panel",
+	"name": "Bank Account Update Request",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "System Manager",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Flash Admin",
+			"write": 1
+		}
+	],
+	"row_format": "Dynamic",
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": []
+}

--- a/admin_panel/admin_panel/doctype/bank_account_update_request/bank_account_update_request.py
+++ b/admin_panel/admin_panel/doctype/bank_account_update_request/bank_account_update_request.py
@@ -1,0 +1,6 @@
+import frappe
+from frappe.model.document import Document
+
+
+class BankAccountUpdateRequest(Document):
+	pass

--- a/admin_panel/api/admin_api.py
+++ b/admin_panel/api/admin_api.py
@@ -361,7 +361,7 @@ def approve_bank_account_update_request(request_id):
 	if req.status != "Pending":
 		return {"success": False, "error": f"Request has already been {req.status.lower()}"}
 
-	if not req.bank_name or not req.account_number:
+	if not req.bank_name or not req.bank_branch or not req.account_type or not req.account_number:
 		return {"success": False, "error": "Request is missing required bank details."}
 
 	bank_account = frappe.get_doc("Bank Account", req.bank_account, for_update=True)

--- a/admin_panel/api/admin_api.py
+++ b/admin_panel/api/admin_api.py
@@ -349,6 +349,113 @@ def reject_upgrade_request(request_id, reason=None):
 @frappe.whitelist()
 @require_admin()
 @handle_api_errors
+def approve_bank_account_update_request(request_id):
+	"""Approve a bank account update request by patching the Bank Account in place.
+
+	The Bank Account document's `name` (and its `is_default` flag) are preserved so
+	that in-flight cashout offers and Cashout documents that reference the account
+	by name keep resolving. Currency is never changed (it is locked at request time).
+	"""
+	req = frappe.get_doc("Bank Account Update Request", request_id, for_update=True)
+
+	if req.status != "Pending":
+		return {"success": False, "error": f"Request has already been {req.status.lower()}"}
+
+	if not req.bank_name or not req.account_number:
+		return {"success": False, "error": "Request is missing required bank details."}
+
+	bank_account = frappe.get_doc("Bank Account", req.bank_account, for_update=True)
+
+	# Re-verify ownership at approval time (mirror of Cashout.validate).
+	if bank_account.party_type != "Customer" or bank_account.party != req.party:
+		return {"success": False, "error": "Bank Account does not belong to the requesting customer."}
+
+	# Reject a collision with a different account's number (mirror of create-time dedupe).
+	if req.account_number and frappe.db.exists(
+		"Bank Account",
+		{"bank_account_no": req.account_number, "name": ["!=", bank_account.name]},
+	):
+		return {"success": False, "error": "Another bank account already uses that account number."}
+
+	old_values = {
+		"bank": bank_account.bank,
+		"branch_code": bank_account.branch_code,
+		"account_type": bank_account.account_type,
+		"bank_account_no": bank_account.bank_account_no,
+	}
+
+	# Ensure the Bank master exists before linking to it (mirror of _create_erp_records).
+	if req.bank_name and not frappe.db.exists("Bank", req.bank_name):
+		frappe.get_doc({"doctype": "Bank", "bank_name": req.bank_name}).insert(ignore_permissions=True)
+
+	# Patch in place. `name` and `is_default` are intentionally left untouched.
+	bank_account.bank = req.bank_name
+	bank_account.branch_code = req.bank_branch or ""
+	bank_account.account_type = req.account_type or ""
+	bank_account.bank_account_no = req.account_number
+	bank_account.save(ignore_permissions=True)
+
+	req.status = "Approved"
+	req.save()
+
+	# Supersede any other still-open requests for the same account so a stale
+	# duplicate can't later be approved and revert the account to old details.
+	siblings = frappe.get_all(
+		"Bank Account Update Request",
+		filters={"bank_account": req.bank_account, "status": "Pending", "name": ["!=", req.name]},
+		pluck="name",
+	)
+	for sibling in siblings:
+		frappe.db.set_value("Bank Account Update Request", sibling, "status", "Closed")
+
+	frappe.db.commit()
+
+	audit_log(
+		"approve_bank_account_update",
+		"Bank Account Update Request",
+		request_id,
+		{
+			"bank_account": req.bank_account,
+			"old": old_values,
+			"new": {
+				"bank": req.bank_name,
+				"branch_code": req.bank_branch,
+				"account_type": req.account_type,
+				"bank_account_no": req.account_number,
+			},
+		},
+	)
+
+	return {"success": True, "message": "Bank account details updated."}
+
+
+@frappe.whitelist()
+@require_admin()
+@handle_api_errors
+def reject_bank_account_update_request(request_id, reason=None):
+	"""Reject a bank account update request (local record only; account unchanged)."""
+	req = frappe.get_doc("Bank Account Update Request", request_id, for_update=True)
+
+	if req.status != "Pending":
+		return {"success": False, "error": f"Request has already been {req.status.lower()}"}
+
+	req.status = "Rejected"
+	req.support_note = reason or "No reason provided"
+	req.save()
+
+	frappe.db.commit()
+	audit_log(
+		"reject_bank_account_update",
+		"Bank Account Update Request",
+		request_id,
+		{"reason": reason or "No reason provided"},
+	)
+	return {"success": True, "message": "Request rejected."}
+
+
+@frappe.whitelist()
+@require_admin()
+@handle_api_errors
 def get_id_document_url(file_key):
 	"""Get pre-signed URL for ID document from Digital Ocean Spaces"""
 	if not file_key:

--- a/admin_panel/tests/test_bank_account_update_request_page_contract.py
+++ b/admin_panel/tests/test_bank_account_update_request_page_contract.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ADMIN_PANEL = REPO_ROOT / "admin_panel"
+DOCTYPE_DIR = ADMIN_PANEL / "admin_panel" / "doctype" / "bank_account_update_request"
+
+
+def read_text(path):
+	return path.read_text()
+
+
+def test_admin_api_exposes_bank_account_update_endpoints():
+	api_py = read_text(ADMIN_PANEL / "api" / "admin_api.py")
+	assert "def approve_bank_account_update_request" in api_py
+	assert "def reject_bank_account_update_request" in api_py
+	assert "Bank Account Update Request" in api_py
+
+
+def test_approve_patches_in_place_preserving_identity():
+	api_py = read_text(ADMIN_PANEL / "api" / "admin_api.py")
+	# The patch must load the existing Bank Account doc (preserving its `name`),
+	# never delete + recreate.
+	assert 'frappe.get_doc("Bank Account", req.bank_account, for_update=True)' in api_py
+	assert "bank_account.save(ignore_permissions=True)" in api_py
+	# `is_default` must be left untouched so it survives the patch.
+	assert "bank_account.is_default" not in api_py
+	# Ownership is re-verified at approval time.
+	assert "bank_account.party != req.party" in api_py
+
+
+def test_doctype_definition():
+	data = json.loads(read_text(DOCTYPE_DIR / "bank_account_update_request.json"))
+	assert data["name"] == "Bank Account Update Request"
+	assert data["module"] == "Admin Panel"
+	fieldnames = {f["fieldname"] for f in data["fields"]}
+	for expected in (
+		"party",
+		"bank_account",
+		"status",
+		"bank_name",
+		"bank_branch",
+		"account_type",
+		"account_number",
+		"currency",
+		"support_note",
+	):
+		assert expected in fieldnames
+	status_field = next(f for f in data["fields"] if f["fieldname"] == "status")
+	assert status_field["options"] == "Pending\nApproved\nRejected\nClosed"
+
+
+def test_controller_class_present():
+	controller = read_text(DOCTYPE_DIR / "bank_account_update_request.py")
+	assert "class BankAccountUpdateRequest(Document)" in controller
+
+
+def test_approve_guards_incomplete_and_supersedes_siblings():
+	api_py = read_text(ADMIN_PANEL / "api" / "admin_api.py")
+	# Incomplete requests are rejected rather than blanking the live account.
+	assert "missing required bank details" in api_py
+	# Other still-open requests for the same account are closed on approval.
+	assert 'set_value("Bank Account Update Request", sibling, "status", "Closed")' in api_py


### PR DESCRIPTION
## What & why

Admin / ERPNext side of **ENG-509** — the DocType the flash backend writes to, plus the approve/reject endpoints. (Companion PRs in `flash` and `flash-mobile`.)

## Changes

- New **`Bank Account Update Request`** DocType (`party`, `bank_account`, `status`, proposed `bank_name` / `bank_branch` / `account_type` / `account_number` / `currency`, `support_note`) + controller.
- **`approve_bank_account_update_request`** — patches the linked **Bank Account in place**, preserving the doc `name` and `is_default` so in-flight cashout offers / Cashout docs keep resolving. Re-verifies ownership (`party`), rejects duplicate `bank_account_no` and incomplete requests, closes sibling Pending requests, and audit-logs the old→new diff.
- **`reject_bank_account_update_request`** — marks Rejected with a support note.

## Invariants

- **In-place patch** — the Bank Account doc `name` and `is_default` are never changed (delete+recreate would orphan cashout offers that reference the account by name).
- **Ownership re-checked at approval** (mirror of `Cashout.validate`).
- **One winner** — approval closes other still-open requests for the same account so a stale duplicate can't later revert it.

## Testing

`ruff check` ✓ · `ruff format --check` ✓ · DocType JSON parses ✓ · contract test `test_bank_account_update_request_page_contract.py` (incl. in-place-patch identity + incomplete-guard/supersede assertions) ✓.

## Note

The admin review surface is the standard Frappe DocType list/form plus these endpoints. A dedicated side-by-side old/new diff workspace page is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
