### PR TITLE
fix: show real error text in Account Hub instead of "[object Object]"

### DIFF
--- a/admin_panel/admin_panel/page/account_hub/account_hub.js
+++ b/admin_panel/admin_panel/page/account_hub/account_hub.js
@@ -147,6 +147,22 @@ function formatCurrency(cents, currency) {
 	return sym + (cents / 100).toFixed(2);
 }
 
+function formatApiErrors(errors) {
+	// Flash GraphQL mutations return validation failures as an array of
+	// { message } objects, not strings. String()-ing them (e.g. via
+	// Array.join) renders "[object Object]" — pull the message out of each.
+	if (!errors) return "";
+	const list = Array.isArray(errors) ? errors : [errors];
+	return list
+		.map((e) => {
+			if (typeof e === "string") return e;
+			if (e && typeof e === "object") return e.message || e.error || JSON.stringify(e);
+			return e == null ? "" : String(e);
+		})
+		.filter(Boolean)
+		.join(", ");
+}
+
 /* ─────────────────────────────────────────────
    AccountHub Class
    ───────────────────────────────────────────── */
@@ -1391,9 +1407,7 @@ class AccountHub {
 							frappe.msgprint({
 								title: "Error",
 								indicator: "red",
-								message: Array.isArray(result.errors)
-									? result.errors.join(", ")
-									: result.errors,
+								message: formatApiErrors(result.errors),
 							});
 						} else {
 							frappe.show_alert(
@@ -1462,9 +1476,7 @@ class AccountHub {
 							frappe.msgprint({
 								title: "Error",
 								indicator: "red",
-								message: Array.isArray(result.errors)
-									? result.errors.join(", ")
-									: result.errors,
+								message: formatApiErrors(result.errors),
 							});
 						} else {
 							frappe.show_alert(
@@ -1532,9 +1544,7 @@ class AccountHub {
 							frappe.msgprint({
 								title: "Error",
 								indicator: "red",
-								message: Array.isArray(result.errors)
-									? result.errors.join(", ")
-									: result.errors,
+								message: formatApiErrors(result.errors),
 							});
 						} else {
 							frappe.show_alert(
@@ -1579,9 +1589,7 @@ class AccountHub {
 						frappe.msgprint({
 							title: "Error",
 							indicator: "red",
-							message: Array.isArray(result.errors)
-								? result.errors.join(", ")
-								: result.errors,
+							message: formatApiErrors(result.errors),
 						});
 					} else {
 						frappe.show_alert(
@@ -1620,9 +1628,7 @@ class AccountHub {
 							frappe.msgprint({
 								title: "Error",
 								indicator: "red",
-								message: Array.isArray(result.errors)
-									? result.errors.join(", ")
-									: result.errors,
+								message: formatApiErrors(result.errors),
 							});
 						} else {
 							frappe.show_alert(


### PR DESCRIPTION
## The bug

The Account Hub error dialog shows **`[object Object]`** instead of the real reason a mutation failed:

![bug](https://media.discordapp.net/attachments/1110270966908592139/1525919223132590191/image.png?format=webp)

## Root cause

Every Flash GraphQL mutation the page calls returns validation failures as an **array of `{ message }` objects** — e.g. `accountUpdateLevel` returns `errors { message }`. All five Account Hub action handlers rendered them with:

```js
message: Array.isArray(result.errors) ? result.errors.join(", ") : result.errors
```

`Array.join` calls `String()` on each element, so `[{message: "..."}]` becomes `"[object Object]"`. The screenshot is the **Change Level** action — the mutation returned a real business-logic reason and the UI threw the text away.

The same latent bug was present in all five handlers: **Change Level, Lock/Activate, Update Phone, Validate Merchant, Delete Merchant.**

## The fix

Add a single `formatApiErrors()` helper that extracts `.message` from each error object and route all five handlers through it.

- `[{message}]` (the bug) → renders the actual message
- multiple errors → comma-joined messages
- plain strings / string arrays → unchanged (backward compatible)
- unexpected object shapes → JSON fallback instead of `[object Object]`

## Verification

- `node --check` passes on the file.
- Exercised the helper against every real error shape; the bug case now renders `"Account is already at MERCHANT level"` instead of `"[object Object]"`, with no regression on string/array inputs.

## Manual test plan (TEST → PROD)

1. Open **Admin Panel → Account Hub**, select an account.
2. Trigger a mutation that the Flash API will reject — easiest is **Change Level** to a level the account can't move to (or **Lock** an already-locked account).
3. Confirm the Error dialog now shows a human-readable reason, not `[object Object]`.

## Out of scope (noted, not changed)

The `error:` callbacks on these same `frappe.call`s read `err?.responseJSON?.exception || err?.message`, which doesn't surface the server message when an endpoint returns via the `@handle_api_errors` decorator (that lands at `err.responseJSON.message.error`). Genuine 500s currently show the generic "Failed to …" fallback. Happy to follow up separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)