### PR TITLE
fix: pass erpParty when changing account level to Pro/Merchant

### DIFF
--- a/admin_panel/admin_panel/page/account_hub/account_hub.js
+++ b/admin_panel/admin_panel/page/account_hub/account_hub.js
@@ -1392,12 +1392,32 @@ class AccountHub {
 				const selectedOption = options.find((o) => o.label === values.new_level);
 				if (!selectedOption) return;
 
+				// Flash requires an ERP party for level 2 (Pro) and 3 (Merchant)
+				// accounts. Existing Pro/Merchant accounts already carry one — pass
+				// it back so a re-level doesn't strip it. Minting a new party is the
+				// upgrade-request approval flow's job (it creates the ERP Customer/
+				// Address/Bank records), so don't fabricate one here.
+				const needsErpParty =
+					selectedOption.value === ACCOUNT_LEVELS.TWO ||
+					selectedOption.value === ACCOUNT_LEVELS.THREE;
+				if (needsErpParty && !account.erpParty) {
+					frappe.msgprint({
+						title: "ERP Party Required",
+						indicator: "orange",
+						message: `${
+							ACCOUNT_LEVEL_LABELS[selectedOption.value]
+						} accounts require an ERP party, and this account has none. Approve an account upgrade request instead — that flow creates the ERP Customer, Address, and Bank Account records.`,
+					});
+					return;
+				}
+
 				d.hide();
 				frappe.call({
 					method: "admin_panel.api.admin_api.update_account_level",
 					args: {
 						uid: account.id || account.uuid,
 						level: selectedOption.value,
+						erp_party: needsErpParty ? account.erpParty : undefined,
 					},
 					freeze: true,
 					freeze_message: "Updating account level...",

--- a/admin_panel/api/admin_api.py
+++ b/admin_panel/api/admin_api.py
@@ -27,10 +27,15 @@ def get_account_by_phone(phone):
 @frappe.whitelist()
 @require_admin()
 @handle_api_errors
-def update_account_level(uid, level):
-	"""Update account level"""
+def update_account_level(uid, level, erp_party=None):
+	"""Update account level.
+
+	Flash requires an erpParty for level TWO/THREE accounts. Existing Pro/
+	Merchant accounts already have one, so the Account Hub passes it back to
+	avoid stripping it on a re-level. Creating a brand-new party is the
+	upgrade-request approval flow's job (see _create_erp_records)."""
 	client = GraphQLClient()
-	return client.update_account_level(uid, level)
+	return client.update_account_level(uid, level, erp_party=erp_party)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Problem

After #52 surfaced real backend errors, **Change Level** in Account Hub fails with:

> erpParty is required for level 2 and 3 accounts

...even for a **THREE → TWO downgrade** of an account that already has an ERP party (e.g. the account's ERP Party is shown right there in the Overview). So Pro/Merchant re-leveling is currently impossible from this button.

## Root cause

Flash's `accountUpdateLevel` mutation requires an `erpParty` whenever the *resulting* level is TWO (Pro) or THREE (Merchant). The plumbing was half-built:

- `GraphQLClient.update_account_level(uid, level, erp_party=None)` already accepts it.
- But `admin_api.update_account_level(uid, level)` didn't take or forward it, and the `change_level` dialog sent only `{uid, level}`.

The account object already carries `erpParty` (rendered in the Overview) — it just wasn't passed back into the mutation. The correct precedent already exists in `approve_upgrade_request` (admin_api.py), which supplies `erp_party` for TWO/THREE.

## Fix

- **`admin_api.update_account_level`** — accept `erp_party=None` and forward it to the client.
- **`change_level` (JS)** — when the target level is TWO/THREE, pass the account's existing `erpParty`. If such an account has *no* party, block with an actionable message pointing to the **upgrade-request approval** flow (the only path that mints the ERP Customer/Address/Bank records) instead of fabricating a dangling party.

Downgrades to ZERO/ONE and re-leveling of accounts that already have a party work; the mint-a-new-party case is intentionally still routed through upgrade-request approval.

## Verification

- `node --check` on the page JS and `py_compile` on `admin_api.py` both pass.
- The prior error was "erpParty is required" (not "account not found"), which confirms `uid` already resolves and `erpParty` was the only missing input.
- End-to-end check on TEST: select a Merchant (level THREE) account with an ERP party → Change Level → **Pro** → expect success, and the level badge updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)