### PR TITLE
fix: self-heal Flash backend service-account role grants on migrate

### DIFF
--- a/admin_panel/admin_panel/setup.py
+++ b/admin_panel/admin_panel/setup.py
@@ -5,6 +5,7 @@ from admin_panel.admin_panel.doctype.allowed_country.seed import seed_allowed_co
 
 def after_migrate():
 	ensure_roles()
+	ensure_service_account_roles()
 	sync_pages()
 	delete_legacy_pages()
 	seed_allowed_countries()
@@ -23,6 +24,49 @@ def ensure_roles():
 			role.desk_access = 1
 			role.flags.ignore_permissions = True
 			role.insert()
+	frappe.db.commit()
+
+
+# One Flash backend service-account User per environment (prod / test). Whichever
+# exists on this site gets the roles; the other is simply absent. Optional
+# `flash_service_account` site_config key overrides the list without a code change.
+SERVICE_ACCOUNT_CANDIDATES = (
+	"flash_sa@getflash.io",
+	"flash-service-account@getflash.io",
+)
+
+# Flash Admin gates the admin_panel custom doctypes (Account Upgrade Request,
+# Bank Account Update Request); Accounts Manager gates the standard ERPNext
+# doctypes the flash backend reads (Bank Account, Currency Exchange, Customer,
+# Journal Entry, Bank). Losing either breaks a slice of cashout/upgrade with 403s.
+SERVICE_ACCOUNT_ROLES = ("Flash Admin", "Accounts Manager")
+
+
+def ensure_service_account_roles():
+	"""Idempotently re-assert the Flash backend service account's roles.
+
+	Role *definitions* ship in doctype JSON (versioned); the role *assignment* on
+	the User record is not, and has silently dropped before — breaking cashout and
+	the upgrade flow with 403s. This runs on every ``bench migrate`` (via
+	after_migrate), so the assignment self-heals on every deploy.
+	"""
+	configured = frappe.conf.get("flash_service_account")
+	candidates = [configured] if configured else list(SERVICE_ACCOUNT_CANDIDATES)
+	for email in candidates:
+		if not email or not frappe.db.exists("User", email):
+			continue
+		existing = {
+			r.role
+			for r in frappe.get_all(
+				"Has Role",
+				filters={"parent": email, "parenttype": "User"},
+				fields=["role"],
+			)
+		}
+		missing = [r for r in SERVICE_ACCOUNT_ROLES if r not in existing]
+		if not missing:
+			continue  # already converged — no needless User.save() this migrate
+		frappe.get_doc("User", email).add_roles(*missing)
 	frappe.db.commit()
 
 


### PR DESCRIPTION
## Problem

The Flash backend service account needs two ERPNext roles to serve cashout and the account-upgrade flow:

- **Flash Admin** — gates the admin_panel custom doctypes (Account Upgrade Request, Bank Account Update Request)
- **Accounts Manager** — gates the standard ERPNext doctypes the backend reads (Bank Account, Currency Exchange, Customer, Journal Entry, Bank)

Role **definitions** ship in doctype JSON and are versioned/safe. Role **assignments** on the User record are **not** versioned — and this week the `Flash Admin` assignment silently dropped, 403'ing cashout and the upgrade flow until an operator re-granted it by hand. Nothing in the app re-asserted it.

`after_migrate()` already called `ensure_roles()`, but that only **creates** the `Flash Admin` Role record — it never **assigns** it to the service account. That was the gap.

## Fix

Add `ensure_service_account_roles()` to `after_migrate`, so the assignment re-asserts on every `bench migrate` (i.e. every deploy):

- **Per-env candidate list** — `flash_sa@getflash.io` (prod) and `flash-service-account@getflash.io` (test). Whichever User exists on the site gets the roles; the other is simply absent. A `flash_service_account` key in site_config overrides the list without a code change.
- **Idempotent** — only calls `add_roles()` for a role that's actually missing, so a converged site does no needless `User.save()` per migrate.
- **No privilege-escalation heuristic** — deliberately does *not* grant based on "any user with an api_key." Live data shows non-service users (e.g. a human admin) also hold api_keys, so that heuristic would hand them the service roles. The candidate list is explicit.

Placed in `after_migrate` (runs every migrate, correct for a self-healing invariant) rather than a Frappe patch (runs once via patch_log — wrong for self-heal).

## Testing

Acceptance-tested on TEST ERPNext:

| Step | Service-account roles |
|------|----------------------|
| Before | `Accounts Manager, Flash Admin` |
| After dropping Flash Admin (simulated regression) | `Accounts Manager` |
| **After `ensure_service_account_roles()`** | `Accounts Manager, Flash Admin` ✓ |
| After re-run (idempotency) | `Accounts Manager, Flash Admin` ✓ (no write) |

`python3 -m py_compile` clean; no mixed tab/space indentation.

## Deploy

Ships on the next ERP image tag → `values.base.yaml` bump → `make erp`. The self-heal takes effect during that deploy's `bench migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)