### PR TITLE
Add Bridge KYC card to the Admin Dashboard tools grid

### DIFF
--- a/admin_panel/admin_panel/page/admin_dashboard/admin_dashboard.js
+++ b/admin_panel/admin_panel/page/admin_dashboard/admin_dashboard.js
@@ -236,6 +236,11 @@ class OpsDashboard {
                         <div><div class="ad-tool-title">Transfer Requests</div>
                         <div class="ad-tool-desc">Cashout and Bridge settlement queue</div></div>
                     </div>
+                    <div class="ad-tool-card" data-route="/app/bridge-kyc">
+                        <div class="ad-tool-icon">BK</div>
+                        <div><div class="ad-tool-title">Bridge KYC</div>
+                        <div class="ad-tool-desc">Live Bridge KYC status for every customer</div></div>
+                    </div>
                     <div class="ad-tool-card" data-route="/app/account-management">
                         <div class="ad-tool-icon">AM</div>
                         <div><div class="ad-tool-title">Account Management</div>

--- a/admin_panel/tests/test_bridge_kyc_page_contract.py
+++ b/admin_panel/tests/test_bridge_kyc_page_contract.py
@@ -141,3 +141,9 @@ def test_api_key_never_reaches_the_client():
 	the overview/detail payloads are built from explicit whitelisted fields."""
 	assert "bridge_api_key" not in PAGE_JS
 	assert "api_key" not in PAGE_JS
+
+
+def test_admin_dashboard_tools_grid_links_the_page():
+	dashboard_js = read(ADMIN_PANEL / "admin_panel" / "page" / "admin_dashboard" / "admin_dashboard.js")
+	assert 'data-route="/app/bridge-kyc"' in dashboard_js
+	assert 'ad-tool-title">Bridge KYC' in dashboard_js


### PR DESCRIPTION
Follow-up to #56: the Bridge KYC page gets a card in the Admin Dashboard Tools section, between Transfer Requests and Account Management. Uses the existing `ad-tool-card` / `data-route` pattern (click wiring is shared, no new JS), plus a contract test pinning the card. Suite 114 pass / 0 fail.

Page-JS-only change — image rebuild, no migrate; `bench clear-cache` post-deploy as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iEVSCGxZMRjwsmSsd6ZNU