### PR TITLE
fix(referral-rewards): show every invite in the table, not just redeemed

### DIFF
--- a/admin_panel/admin_panel/page/referral_rewards/referral_rewards.js
+++ b/admin_panel/admin_panel/page/referral_rewards/referral_rewards.js
@@ -1,7 +1,8 @@
 const RR_ALLOWED_ROLES = ["Accounts Manager", "Flash Admin", "System Manager"];
 
 // Reward-status buckets (clickable filters). Keys match the invite rewardStatus
-// (plus "unrewarded" for accepted-but-not-yet-paid and "all").
+// (plus "unrewarded" for accepted-but-not-yet-paid, "sent"/"expired" for
+// un-redeemed invite lifecycle rows, and "all").
 const RR_BUCKETS = [
 	{ key: "all", label: "All" },
 	{ key: "paid", label: "Paid" },
@@ -10,6 +11,8 @@ const RR_BUCKETS = [
 	{ key: "failed", label: "Failed" },
 	{ key: "processing", label: "Processing" },
 	{ key: "unrewarded", label: "Unrewarded" },
+	{ key: "sent", label: "Sent" },
+	{ key: "expired", label: "Expired" },
 ];
 
 const RR_STATUS_TONE = {
@@ -21,6 +24,13 @@ const RR_STATUS_TONE = {
 	failed: "bad",
 	processing: "warn",
 	unrewarded: "",
+	// Un-redeemed invite lifecycle rows — informational, not actionable.
+	sent: "",
+	expired: "",
+	// PENDING invite (created, delivery unconfirmed) — mapped server-side to
+	// "unsent" so it can't collide with the IBEX reward "pending" bucket. A
+	// stuck-unsent invite is worth a second look, so it tones as a warning.
+	unsent: "warn",
 };
 
 const RR_CSS = `
@@ -223,7 +233,7 @@ class ReferralRewards {
 				const capNote =
 					rowsShown < rowsTotal ? ` (showing latest ${rowsShown} of ${rowsTotal})` : "";
 				this.set_status(
-					`Live view — ${rowsTotal} redeemed referrals${capNote}. Updated ${rr_ago(
+					`Live view — ${rowsTotal} invites${capNote}. Updated ${rr_ago(
 						this.now,
 						this.now
 					)}.`
@@ -336,6 +346,14 @@ class ReferralRewards {
 				s.unrewarded === undefined
 					? this.rows.filter((r) => r.reward_status === "unrewarded").length
 					: s.unrewarded,
+			sent:
+				s.invites_sent_open === undefined
+					? this.rows.filter((r) => r.reward_status === "sent").length
+					: s.invites_sent_open,
+			expired:
+				s.invites_expired === undefined
+					? this.rows.filter((r) => r.reward_status === "expired").length
+					: s.invites_expired,
 		};
 		const html = RR_BUCKETS.map((b) => {
 			const active = b.key === this.active_bucket ? " active" : "";
@@ -387,13 +405,13 @@ class ReferralRewards {
                 <td><span class="rr-chip-st ${tone}">${esc(r.reward_status)}</span>${err}</td>
                 <td style="text-align:center">${paidMark(r.inviter_paid)}</td>
                 <td style="text-align:center">${paidMark(r.invitee_paid)}</td>
-                <td>${esc(rr_ago(r.rewarded_at || r.redeemed_at, this.now))}</td>
+                <td>${esc(rr_ago(r.rewarded_at || r.redeemed_at || r.created_at, this.now))}</td>
             </tr>`;
 			})
 			.join("");
 		this.page.main.find("#rr-table").html(`
             <div class="rr-card">
-                <div class="rr-count">Showing ${rows.length} referral${
+                <div class="rr-count">Showing ${rows.length} invite${
 			rows.length === 1 ? "" : "s"
 		}</div>
                 <div style="overflow-x:auto">

--- a/admin_panel/api/referral_rewards_core.py
+++ b/admin_panel/api/referral_rewards_core.py
@@ -34,10 +34,14 @@ REWARDED_STATUSES = {"paid", "partial", "pending"}
 KNOWN_REWARD_STATUSES = ("paid", "partial", "failed", "processing", "pending")
 
 
-def _is_actionable(row_reward_status):
-	"""Rows ops must be able to reach: everything except clean 'paid' and
-	not-yet-rewarded. Unknown (drifted) statuses are actionable by definition."""
-	return row_reward_status not in ("paid", "unrewarded")
+def _is_actionable(row):
+	"""Rows ops must be able to reach: redeemed rows in any state except clean
+	'paid' and not-yet-rewarded. Unknown (drifted) reward statuses are actionable
+	by definition. Un-redeemed rows (sent/expired/...) are lifecycle info, never
+	actionable — they must not bypass the row cap."""
+	if row.get("status") != "ACCEPTED":
+		return False
+	return row.get("reward_status") not in ("paid", "unrewarded")
 
 
 def _tier_amount_cents(tiers, seq):
@@ -94,6 +98,8 @@ def build_overview(invites, accounts, counter_seq, tiers=REWARD_TIERS, wallet_ba
 	status_counts = {status: 0 for status in KNOWN_REWARD_STATUSES}
 	unknown = 0
 	unrewarded = 0
+	invites_sent_open = 0  # SENT: delivered, awaiting redemption
+	invites_expired = 0  # EXPIRED: never redeemed (or revoked)
 	total_invites = len(invites)
 	sent = 0
 	accepted = 0
@@ -135,42 +141,63 @@ def build_overview(invites, accounts, counter_seq, tiers=REWARD_TIERS, wallet_ba
 			bucket["count_parties"] += parties_paid
 			bucket["dollars"] += disbursed / 100.0
 
-		# The table shows only ACCEPTED (redeemed) invites — the ones eligible
-		# for a reward once the invitee's KYC is approved.
+		# Every invite is a table row. ACCEPTED (redeemed) rows carry the reward
+		# lifecycle; un-redeemed rows (SENT/EXPIRED/anything else) surface the
+		# invite lifecycle in the reward column instead — lowercased, so an
+		# unknown backend status renders fail-visible (the page tones unlisted
+		# values as warnings), matching the reward-status drift philosophy.
+		inviter = accounts.get(inv.get("inviter_id")) or {}
 		if status == "ACCEPTED":
 			if not reward_status:
 				unrewarded += 1
-			inviter = accounts.get(inv.get("inviter_id")) or {}
 			invitee = accounts.get(inv.get("redeemed_by_id")) or {}
-			rows.append(
-				{
-					"invite_id": inv.get("invite_id"),
-					"invitee": invitee.get("username") or inv.get("contact") or "—",
-					"inviter": inviter.get("username") or "—",
-					"status": status,
-					"reward_status": reward_status or "unrewarded",
-					"reward_amount_dollars": (amount_cents / 100.0) if amount_cents else None,
-					"reward_seq": inv.get("reward_seq"),
-					"redeemed_at": inv.get("redeemed_at"),
-					"rewarded_at": inv.get("rewarded_at"),
-					"inviter_paid": inviter_paid,
-					"invitee_paid": invitee_paid,
-					"reward_error": inv.get("reward_error"),
-				}
-			)
+			row_invitee = invitee.get("username") or inv.get("contact") or "—"
+			row_reward_status = reward_status or "unrewarded"
+		else:
+			row_invitee = inv.get("contact") or "—"
+			if status == "SENT":
+				invites_sent_open += 1
+				row_reward_status = "sent"
+			elif status == "EXPIRED":
+				invites_expired += 1
+				row_reward_status = "expired"
+			elif status == "PENDING":
+				# "unsent", NOT "pending": the IBEX reward-status bucket already
+				# owns "pending" — a lifecycle collision would leak these rows
+				# into the money-moved reconciliation filter.
+				row_reward_status = "unsent"
+			else:
+				row_reward_status = (status or "unknown").lower()
+		rows.append(
+			{
+				"invite_id": inv.get("invite_id"),
+				"invitee": row_invitee,
+				"inviter": inviter.get("username") or "—",
+				"status": status,
+				"reward_status": row_reward_status,
+				"reward_amount_dollars": (amount_cents / 100.0) if amount_cents else None,
+				"reward_seq": inv.get("reward_seq"),
+				"created_at": inv.get("created_at"),
+				"redeemed_at": inv.get("redeemed_at"),
+				"rewarded_at": inv.get("rewarded_at"),
+				"inviter_paid": inviter_paid,
+				"invitee_paid": invitee_paid,
+				"reward_error": inv.get("reward_error"),
+			}
+		)
 
-	rows.sort(key=lambda r: (r.get("redeemed_at") or ""), reverse=True)
+	rows.sort(key=lambda r: (r.get("redeemed_at") or r.get("created_at") or ""), reverse=True)
 	rows_total = len(rows)
 	if max_rows is not None and rows_total > max_rows:
 		# Actionable rows (failed/partial/pending/processing/unknown) must never
 		# be hidden by the cap — they are the rare rows ops has to reconcile.
 		# Only paid/unrewarded rows consume the cap budget; overall newest-first
 		# order is preserved by the single pass over the sorted list.
-		actionable_total = sum(1 for r in rows if _is_actionable(r["reward_status"]))
+		actionable_total = sum(1 for r in rows if _is_actionable(r))
 		budget = max(0, max_rows - actionable_total)
 		kept = []
 		for r in rows:
-			if _is_actionable(r["reward_status"]):
+			if _is_actionable(r):
 				kept.append(r)
 			elif budget > 0:
 				kept.append(r)
@@ -205,6 +232,8 @@ def build_overview(invites, accounts, counter_seq, tiers=REWARD_TIERS, wallet_ba
 		"pending": status_counts["pending"],
 		"unknown": unknown,
 		"unrewarded": unrewarded,
+		"invites_sent_open": invites_sent_open,
+		"invites_expired": invites_expired,
 		"needs_reconciliation": (
 			status_counts["partial"] + status_counts["failed"] + status_counts["pending"] + unknown
 		),

--- a/admin_panel/tests/test_referral_rewards_core.py
+++ b/admin_panel/tests/test_referral_rewards_core.py
@@ -139,7 +139,7 @@ def _fixture():
 			"invitee_rewarded_at": None,
 			"reward_error": None,
 		},
-		# sent but never redeemed — not in the table, counts toward funnel
+		# sent but never redeemed — a lifecycle table row, counts toward funnel
 		{
 			"invite_id": "i5",
 			"status": "SENT",
@@ -149,6 +149,7 @@ def _fixture():
 			"reward_status": None,
 			"reward_seq": None,
 			"reward_amount_cents": None,
+			"created_at": "2026-08-01T09:00:00",
 			"redeemed_at": None,
 			"rewarded_at": None,
 			"inviter_rewarded_at": None,
@@ -165,6 +166,7 @@ def _fixture():
 			"reward_status": None,
 			"reward_seq": None,
 			"reward_amount_cents": None,
+			"created_at": "2026-07-27T09:00:00",
 			"redeemed_at": None,
 			"rewarded_at": None,
 			"inviter_rewarded_at": None,
@@ -181,6 +183,7 @@ def _fixture():
 			"reward_status": None,
 			"reward_seq": None,
 			"reward_amount_cents": None,
+			"created_at": "2026-07-26T09:00:00",
 			"redeemed_at": None,
 			"rewarded_at": None,
 			"inviter_rewarded_at": None,
@@ -225,6 +228,8 @@ def test_summary_counts_and_disbursement():
 	assert s["pending"] == 1
 	assert s["unknown"] == 0
 	assert s["unrewarded"] == 1  # i4: accepted, KYC not approved yet
+	assert s["invites_sent_open"] == 1  # i5: delivered, awaiting redemption
+	assert s["invites_expired"] == 1  # i7
 	assert s["needs_reconciliation"] == 3  # partial + failed + pending + unknown
 
 	# disbursed: i1 both @ $5 = $10; i2 one @ $2.50 = $2.50; i8 both @ $5 = $10.
@@ -245,10 +250,12 @@ def test_expired_counts_as_sent_not_accepted():
 	funnel = {f["stage"]: f for f in out["funnel"]}
 
 	# i7 (EXPIRED) stays in the Sent denominator so Accepted% isn't inflated,
-	# but never counts as Accepted and never appears in the table.
+	# and never counts as Accepted. It DOES appear in the table — as a
+	# lifecycle row, not a reward row.
 	assert funnel["Sent"]["count"] == 7
 	assert funnel["Accepted"]["count"] == 5
-	assert "i7" not in {r["invite_id"] for r in out["rows"]}
+	i7 = next(r for r in out["rows"] if r["invite_id"] == "i7")
+	assert i7["reward_status"] == "expired"
 
 
 def test_disbursed_by_tier():
@@ -263,17 +270,19 @@ def test_disbursed_by_tier():
 	assert tiers[2.5]["dollars"] == 2.5
 
 
-def test_rows_only_accepted_join_usernames_and_flags():
+def test_rows_include_all_invites_join_usernames_and_flags():
 	invites, accounts = _fixture()
 	out = build_overview(invites, accounts, counter_seq=0)
 	rows = out["rows"]
 
-	# Only the 5 ACCEPTED invites appear (SENT/PENDING/EXPIRED excluded).
-	assert len(rows) == 5
-	assert {r["invite_id"] for r in rows} == {"i1", "i2", "i3", "i4", "i8"}
+	# EVERY invite is a row — redeemed ones carry the reward lifecycle,
+	# un-redeemed ones (SENT/PENDING/EXPIRED) the invite lifecycle.
+	assert len(rows) == 8
+	assert {r["invite_id"] for r in rows} == {f"i{n}" for n in range(1, 9)}
 
-	# Newest-redeemed first.
-	assert rows[0]["invite_id"] == "i4"
+	# Newest-first by redeemed_at, falling back to created_at for
+	# un-redeemed rows (i5 was created after every redemption).
+	assert [r["invite_id"] for r in rows] == ["i5", "i4", "i1", "i2", "i3", "i8", "i6", "i7"]
 
 	by_id = {r["invite_id"]: r for r in rows}
 	# usernames joined from accounts
@@ -292,6 +301,16 @@ def test_rows_only_accepted_join_usernames_and_flags():
 	assert by_id["i8"]["reward_status"] == "pending"
 	assert by_id["i8"]["inviter_paid"] is True
 	assert by_id["i8"]["invitee_paid"] is True
+	# lifecycle rows: reward column mirrors the invite status; the invitee cell
+	# falls back to the contact; the inviter username still joins.
+	assert by_id["i5"]["reward_status"] == "sent"
+	assert by_id["i5"]["invitee"] == "someone@x.com"
+	assert by_id["i5"]["inviter"] == "alice"
+	assert by_id["i5"]["reward_amount_dollars"] is None
+	assert by_id["i5"]["created_at"] == "2026-08-01T09:00:00"
+	# PENDING maps to "unsent" — NEVER "pending", which the IBEX reward bucket owns.
+	assert by_id["i6"]["reward_status"] == "unsent"
+	assert by_id["i7"]["reward_status"] == "expired"
 
 
 def test_row_cap_truncates_rows_but_not_summary():
@@ -299,18 +318,19 @@ def test_row_cap_truncates_rows_but_not_summary():
 	out = build_overview(invites, accounts, counter_seq=0, max_rows=2)
 
 	# Actionable rows (partial i2, failed i3, pending i8) always survive the
-	# cap; only paid/unrewarded rows consume the budget (here: none, since the
-	# 3 actionable rows already exceed max_rows=2). Summary covers everything.
+	# cap; paid/unrewarded AND un-redeemed lifecycle rows consume the budget
+	# (here: none, since the 3 actionable rows already exceed max_rows=2).
+	# Summary covers everything.
 	assert [r["invite_id"] for r in out["rows"]] == ["i2", "i3", "i8"]
-	assert out["summary"]["rows_total"] == 5
+	assert out["summary"]["rows_total"] == 8
 	assert out["summary"]["rows_shown"] == 3
 	assert out["summary"]["accepted"] == 5
 	assert out["summary"]["total_disbursed_dollars"] == 22.50
 
 	# Uncapped run reports full counts.
 	full = build_overview(invites, accounts, counter_seq=0)
-	assert full["summary"]["rows_total"] == 5
-	assert full["summary"]["rows_shown"] == 5
+	assert full["summary"]["rows_total"] == 8
+	assert full["summary"]["rows_shown"] == 8
 
 
 def test_row_cap_never_hides_actionable_rows():
@@ -442,3 +462,56 @@ def test_default_tiers_are_the_backend_schedule():
 		{"upToCount": 600, "amountCents": 250},
 		{"upToCount": 0, "amountCents": 100},
 	]
+
+
+def test_unredeemed_lifecycle_rows_consume_cap_budget():
+	# Lifecycle rows (sent/unsent/expired) are informational — they must consume
+	# the cap budget like paid rows, never bypass it like actionable rows do.
+	accounts = {}
+	invites = [
+		{
+			"invite_id": "sent-new",
+			"status": "SENT",
+			"inviter_id": None,
+			"redeemed_by_id": None,
+			"contact": "new@x.com",
+			"reward_status": None,
+			"reward_seq": None,
+			"reward_amount_cents": None,
+			"created_at": "2026-08-02T09:00:00",
+			"redeemed_at": None,
+			"rewarded_at": None,
+			"inviter_rewarded_at": None,
+			"invitee_rewarded_at": None,
+			"reward_error": None,
+		},
+		{
+			"invite_id": "revoked-1",  # a lifecycle status this page doesn't know
+			"status": "REVOKED",
+			"inviter_id": None,
+			"redeemed_by_id": None,
+			"contact": "rev@x.com",
+			"reward_status": None,
+			"reward_seq": None,
+			"reward_amount_cents": None,
+			"created_at": "2026-08-01T09:00:00",
+			"redeemed_at": None,
+			"rewarded_at": None,
+			"inviter_rewarded_at": None,
+			"invitee_rewarded_at": None,
+			"reward_error": None,
+		},
+	]
+
+	out = build_overview(invites, accounts, counter_seq=0, max_rows=1)
+	# Neither row is actionable, so the cap truncates to exactly 1 (the newest).
+	assert [r["invite_id"] for r in out["rows"]] == ["sent-new"]
+	assert out["summary"]["rows_total"] == 2
+	assert out["summary"]["rows_shown"] == 1
+
+	# Unknown lifecycle statuses lowercase into the reward column (fail-visible
+	# via the page's unknown-tone fallback), and never collide with "pending".
+	full = build_overview(invites, accounts, counter_seq=0)
+	by_id = {r["invite_id"]: r for r in full["rows"]}
+	assert by_id["revoked-1"]["reward_status"] == "revoked"
+	assert by_id["sent-new"]["reward_status"] == "sent"

--- a/docs/referral-rewards.md
+++ b/docs/referral-rewards.md
@@ -13,7 +13,10 @@ A live ops view of the invite/refer-a-friend reward payouts.
   stage-over-stage conversion. "Sent" includes sent-then-**EXPIRED** invites so
   the Accepted% denominator is honest (the invite model has no `sentAt`, so the
   rare admin-revoked PENDING→EXPIRED invite is also counted as sent).
-- **Per-referral table** — redeemed (`ACCEPTED`) invites: invitee, inviter,
+- **Per-invite table** — every invite: redeemed (`ACCEPTED`) rows carry the
+  reward lifecycle; un-redeemed rows show the invite lifecycle (`sent` /
+  `unsent` / `expired`) in the reward column with the contact as the invitee.
+  Redeemed rows: invitee, inviter,
   amount, tier sequence, reward status (paid / pending / partial / failed /
   processing / unrewarded), per-party paid ✓/✗, any error, and when. Filterable
   by status; the "Needs Reconciliation" tile and the Pending/Partial/Failed


### PR DESCRIPTION
## Problem
The funnel counts all invites but the table listed only `ACCEPTED` (redeemed) rows — outstanding `SENT` invites were invisible. On TEST: "Invited 3 / Sent 3" with a single table row.

## Change
- **Every invite is a row.** Redeemed rows keep the reward lifecycle; un-redeemed rows show the invite lifecycle in the reward column: `sent` / `expired` / `unsent` (PENDING → `unsent` deliberately, so it can **never collide** with the IBEX reward-status `pending` reconciliation bucket). Unknown lifecycle statuses lowercase + warn-tone (fail-visible, same drift philosophy as reward statuses).
- Invitee cell falls back to the invite **contact**; WHEN falls back to `created_at`.
- New **Sent / Expired** filter chips (summary fields `invites_sent_open` / `invites_expired`).
- Lifecycle rows are **never actionable** — they consume the row-cap budget like paid rows, never bypass it.

## Tests
139 passed (was 138): fixture extended with `created_at`, accepted-only expectations updated, new lifecycle-cap + unknown-status-mapping test. ruff (pinned 0.8.1) + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)