### PR TITLE
feat(admin): payer identity on Transfer Requests audit rows

### DIFF
--- a/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
+++ b/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
@@ -1066,7 +1066,10 @@ class TransferRequestsManager {
 		const amountDisplay = this.formatAmount(req.amount, req.currency);
 		const failureDisplay = req.failure_reason ? this.escapeHtml(req.failure_reason) : "-";
 		const requestId = req.request_id || req.name || "-";
-		const payerDisplay = req.payer_username || req.payer_name || "-";
+		// Route through payerValue so provider-sourced (unverified checkout)
+		// values are labeled in the table, not just the detail drawer.
+		const payerDisplay =
+			this.payerValue(req, "payer_username") || this.payerValue(req, "payer_name") || "-";
 
 		const row = $(`
             <tr class="bridge-row" data-request-id="${this.escapeHtml(req.name)}">

--- a/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
+++ b/admin_panel/admin_panel/page/transfer_requests/transfer_requests.js
@@ -812,7 +812,15 @@ class TransferRequestsManager {
 			"Submitted",
 			"Actions",
 		];
-		const bridgeHeaders = ["Request ID", "Type", "Amount", "Status", "Failure", "Last Seen"];
+		const bridgeHeaders = [
+			"Request ID",
+			"Payer",
+			"Type",
+			"Amount",
+			"Status",
+			"Failure",
+			"Last Seen",
+		];
 		const headers = this.active_type !== "cashout" ? bridgeHeaders : cashoutHeaders;
 
 		this.$cache.tableHead.html(`
@@ -1058,10 +1066,12 @@ class TransferRequestsManager {
 		const amountDisplay = this.formatAmount(req.amount, req.currency);
 		const failureDisplay = req.failure_reason ? this.escapeHtml(req.failure_reason) : "-";
 		const requestId = req.request_id || req.name || "-";
+		const payerDisplay = req.payer_username || req.payer_name || "-";
 
 		const row = $(`
             <tr class="bridge-row" data-request-id="${this.escapeHtml(req.name)}">
                 <td><strong>${this.escapeHtml(requestId)}</strong></td>
+                <td>${this.escapeHtml(payerDisplay)}</td>
                 <td>${this.escapeHtml(req.transaction_type || "-")}</td>
                 <td><strong>${this.escapeHtml(amountDisplay)}</strong></td>
                 <td><span class="modern-badge ${statusBadge}">${this.escapeHtml(
@@ -1576,6 +1586,29 @@ class TransferRequestsManager {
 
             <div class="detail-section mb-4">
                 <h6 class="section-header">
+                    <i class="fa fa-user" style="margin-right: 8px; color: var(--color-primary);"></i>
+                    Payer
+                </h6>
+                <div class="row">
+                    <div class="col-md-6">
+                        ${this.renderDetailItem("Full Name", this.payerValue(req, "payer_name"))}
+                        ${this.renderDetailItem(
+							"Username",
+							this.payerValue(req, "payer_username")
+						)}
+                    </div>
+                    <div class="col-md-6">
+                        ${this.renderDetailItem("Email", this.payerValue(req, "payer_email"))}
+                        ${this.renderDetailItem(
+							"Phone",
+							this.payerValue(req, "payer_phone", (v) => this.formatPhone(v))
+						)}
+                    </div>
+                </div>
+            </div>
+
+            <div class="detail-section mb-4">
+                <h6 class="section-header">
                     <i class="fa fa-link" style="margin-right: 8px; color: var(--color-primary);"></i>
                     References
                 </h6>
@@ -1715,6 +1748,17 @@ class TransferRequestsManager {
 	formatPhone(phone) {
 		if (!phone) return "-";
 		return phone.replace(/^(\d{3})(\d{3})(\d{2})(\d{2})$/, "+$1 $2 $3 $4");
+	}
+
+	// Payer identity is resolved server-side (mongo account / ERP customer
+	// first, provider payload as fallback). Values that came from the provider
+	// payload are unverified checkout input, so they get labeled.
+	payerValue(req, field, format) {
+		const raw = req[field];
+		if (!raw) return "";
+		const value = format ? format(raw) : raw;
+		const fromProvider = (req.payer_provider_fields || []).includes(field);
+		return fromProvider ? `${value} (from provider)` : `${value}`;
 	}
 
 	formatDateTime(dt) {

--- a/admin_panel/api/admin_api.py
+++ b/admin_panel/api/admin_api.py
@@ -7,7 +7,12 @@ import requests as requests_lib
 from .auth import audit_log, require_admin, require_financial, require_roles
 from .common import handle_api_errors
 from .graphql_client import GraphQLClient, GraphQLError
-from .transfer_identity_core import build_payer_fields, empty_payer_fields, parse_payload_identity
+from .transfer_identity_core import (
+	build_payer_fields,
+	collect_lookup_refs,
+	empty_payer_fields,
+	match_account_identity,
+)
 
 
 @frappe.whitelist()
@@ -910,27 +915,20 @@ def _attach_payer_identity(rows):
 	Batched per page: one mongo accounts+users lookup for the rows' account
 	ids / payload usernames (mongo_reader.load_payer_identities), plus one
 	ERPNext Customer query for erpParty-linked names/emails — never N queries.
-	Field priority and provider labeling live in transfer_identity_core; any
-	lookup failure leaves the payer_* fields blank.
+	Ref collection, identity matching, field priority, and provider labeling
+	all live in transfer_identity_core (pure, unit-tested); any lookup failure
+	leaves the payer_* fields blank.
 	"""
-	payload_identities = []
-	account_refs = set()
-	usernames = set()
 	for row in rows:
 		row.update(empty_payer_fields())
-		payload_identity = parse_payload_identity(row.get("raw_payload_json"))
-		payload_identities.append(payload_identity)
-		if row.get("account_id"):
-			account_refs.add(str(row["account_id"]))
-		elif payload_identity["username"]:
-			usernames.add(payload_identity["username"])
+	payload_identities, account_refs, usernames = collect_lookup_refs(rows)
 
 	identities = {}
 	if account_refs or usernames:
 		try:
 			from .mongo_reader import load_payer_identities
 
-			identities = load_payer_identities(sorted(account_refs), sorted(usernames))
+			identities = load_payer_identities(account_refs, usernames)
 		except Exception:
 			frappe.log_error(frappe.get_traceback(), "Transfer payer identity mongo lookup failed")
 
@@ -948,11 +946,7 @@ def _attach_payer_identity(rows):
 			frappe.log_error(frappe.get_traceback(), "Transfer payer Customer lookup failed")
 
 	for row, payload_identity in zip(rows, payload_identities, strict=True):
-		account_identity = None
-		if row.get("account_id"):
-			account_identity = identities.get(str(row["account_id"]))
-		if account_identity is None and payload_identity["username"]:
-			account_identity = identities.get(payload_identity["username"])
+		account_identity = match_account_identity(row, payload_identity, identities)
 		customer_info = customers.get((account_identity or {}).get("erp_party"))
 		row.update(
 			build_payer_fields(

--- a/admin_panel/api/admin_api.py
+++ b/admin_panel/api/admin_api.py
@@ -917,7 +917,8 @@ def _attach_payer_identity(rows):
 	ERPNext Customer query for erpParty-linked names/emails — never N queries.
 	Ref collection, identity matching, field priority, and provider labeling
 	all live in transfer_identity_core (pure, unit-tested); any lookup failure
-	leaves the payer_* fields blank.
+	leaves the account-derived fields blank; provider-payload fallbacks still
+	apply (labeled).
 	"""
 	for row in rows:
 		row.update(empty_payer_fields())

--- a/admin_panel/api/admin_api.py
+++ b/admin_panel/api/admin_api.py
@@ -7,6 +7,7 @@ import requests as requests_lib
 from .auth import audit_log, require_admin, require_financial, require_roles
 from .common import handle_api_errors
 from .graphql_client import GraphQLClient, GraphQLError
+from .transfer_identity_core import build_payer_fields, empty_payer_fields, parse_payload_identity
 
 
 @frappe.whitelist()
@@ -903,6 +904,66 @@ def search_cashout_account(id: str):
 	return [_enrich_cashout(r) for r in records]
 
 
+def _attach_payer_identity(rows):
+	"""Best-effort payer enrichment for the audit tabs — never breaks the page.
+
+	Batched per page: one mongo accounts+users lookup for the rows' account
+	ids / payload usernames (mongo_reader.load_payer_identities), plus one
+	ERPNext Customer query for erpParty-linked names/emails — never N queries.
+	Field priority and provider labeling live in transfer_identity_core; any
+	lookup failure leaves the payer_* fields blank.
+	"""
+	payload_identities = []
+	account_refs = set()
+	usernames = set()
+	for row in rows:
+		row.update(empty_payer_fields())
+		payload_identity = parse_payload_identity(row.get("raw_payload_json"))
+		payload_identities.append(payload_identity)
+		if row.get("account_id"):
+			account_refs.add(str(row["account_id"]))
+		elif payload_identity["username"]:
+			usernames.add(payload_identity["username"])
+
+	identities = {}
+	if account_refs or usernames:
+		try:
+			from .mongo_reader import load_payer_identities
+
+			identities = load_payer_identities(sorted(account_refs), sorted(usernames))
+		except Exception:
+			frappe.log_error(frappe.get_traceback(), "Transfer payer identity mongo lookup failed")
+
+	customers = {}
+	erp_parties = sorted({i["erp_party"] for i in identities.values() if i.get("erp_party")})
+	if erp_parties:
+		try:
+			for customer in frappe.get_all(
+				"Customer",
+				filters=[["name", "in", erp_parties]],
+				fields=["name", "customer_name", "mobile_no", "email_id"],
+			):
+				customers[customer["name"]] = customer
+		except Exception:
+			frappe.log_error(frappe.get_traceback(), "Transfer payer Customer lookup failed")
+
+	for row, payload_identity in zip(rows, payload_identities, strict=True):
+		account_identity = None
+		if row.get("account_id"):
+			account_identity = identities.get(str(row["account_id"]))
+		if account_identity is None and payload_identity["username"]:
+			account_identity = identities.get(payload_identity["username"])
+		customer_info = customers.get((account_identity or {}).get("erp_party"))
+		row.update(
+			build_payer_fields(
+				payload_identity=payload_identity,
+				account_identity=account_identity,
+				customer_info=customer_info,
+			)
+		)
+	return rows
+
+
 @frappe.whitelist()
 @require_admin()
 @handle_api_errors
@@ -933,6 +994,9 @@ def get_bridge_transfer_requests(
 			["wallet_id", "like", like_query],
 			["ibex_tx_hash", "like", like_query],
 			["source_event_id", "like", like_query],
+			# Fygaro payloads carry the payer's username (customReference) and
+			# client name/email — searching those must find card top-ups too.
+			["raw_payload_json", "like", like_query],
 		]
 
 	fields = [
@@ -984,7 +1048,7 @@ def get_bridge_transfer_requests(
 
 	total_count = len(count_rows)
 	return {
-		"data": [dict(record) for record in records],
+		"data": _attach_payer_identity([dict(record) for record in records]),
 		"total": total_count,
 		"page": page,
 		"page_size": page_size,

--- a/admin_panel/api/mongo_reader.py
+++ b/admin_panel/api/mongo_reader.py
@@ -278,6 +278,62 @@ def customer_bundle(account: dict) -> dict:
 	}
 
 
+def load_payer_identities(account_refs, usernames) -> dict:
+	"""Batch-resolve payer identity for a page of transfer-request audit rows.
+
+	One accounts query (matching mongo ``_id``, account uuid ``id``, or
+	``username`` — the same handles find_account accepts) plus one users query
+	for phones. The returned dict is keyed by every join handle each account
+	answers to — str(_id), uuid, and username — so the caller can look rows up
+	by whichever ref it has (Bridge rows carry account_id, Fygaro rows often
+	only a customReference username).
+
+	Values: {account_id, username, phone, erp_party}.
+	"""
+	from bson import ObjectId
+
+	account_refs = [str(ref).strip() for ref in (account_refs or []) if ref]
+	usernames = [str(name).strip() for name in (usernames or []) if name]
+	if not account_refs and not usernames:
+		return {}
+
+	ors = []
+	object_ids = [ObjectId(ref) for ref in account_refs if ObjectId.is_valid(ref)]
+	if object_ids:
+		ors.append({"_id": {"$in": object_ids}})
+	if account_refs:
+		ors.append({"id": {"$in": account_refs}})
+	if usernames:
+		ors.append({"username": {"$in": usernames}})
+
+	db = _get_db()
+	accounts = list(
+		db.accounts.find(
+			{"$or": ors},
+			{"_id": 1, "id": 1, "username": 1, "kratosUserId": 1, "erpParty": 1},
+		)
+	)
+
+	kratos_ids = [a["kratosUserId"] for a in accounts if a.get("kratosUserId")]
+	phones = {}
+	if kratos_ids:
+		for user in db.users.find({"kratosUserId": {"$in": kratos_ids}}, {"kratosUserId": 1, "phone": 1}):
+			phones[user["kratosUserId"]] = user.get("phone")
+
+	out = {}
+	for account in accounts:
+		identity = {
+			"account_id": str(account["_id"]),
+			"username": account.get("username"),
+			"phone": phones.get(account.get("kratosUserId")),
+			"erp_party": account.get("erpParty"),
+		}
+		for key in (str(account["_id"]), account.get("id"), account.get("username")):
+			if key:
+				out[key] = identity
+	return out
+
+
 def load_invites() -> list:
 	"""Referral invites with their reward-payout fields.
 

--- a/admin_panel/api/transfer_identity_core.py
+++ b/admin_panel/api/transfer_identity_core.py
@@ -1,0 +1,93 @@
+"""Pure payer-identity resolution for the Transfer Requests audit tabs.
+
+No frappe or IO imports — everything takes plain dicts (parsed provider
+payloads, account identities from mongo_reader, ERPNext Customer rows) so it
+can be unit-tested directly, mirroring census_core / bridge_kyc_core.
+
+Field priority (Flash account truth first, provider payload as fallback):
+  username — accounts.username, else Fygaro ``customReference``
+  name     — ERPNext Customer name (via erpParty), else Fygaro ``client.name``
+  email    — ERPNext Customer email_id, else Fygaro ``client.email``
+  phone    — mongo users.phone (via kratosUserId), else Customer mobile_no
+
+Values that fell back to the provider payload are listed in
+``payer_provider_fields`` so the UI can label them "(from provider)" — a
+Fygaro ``client`` block is whatever the payer typed at checkout, not verified
+Flash identity.
+"""
+
+import json
+
+PAYER_FIELDS = ("payer_name", "payer_username", "payer_email", "payer_phone")
+
+
+def empty_payer_fields():
+	"""Blank payer_* dict — every audit row carries these keys even when
+	enrichment is skipped or fails, so the UI never branches on presence."""
+	out = dict.fromkeys(PAYER_FIELDS, "")
+	out["payer_provider_fields"] = []
+	return out
+
+
+def _clean(value):
+	return value.strip() if isinstance(value, str) else ""
+
+
+def parse_payload_identity(raw_payload_json):
+	"""Extract payer hints from a provider payload (best effort, never raises).
+
+	Fygaro payloads carry ``customReference`` (the Flash username the app sent
+	with the payment) and ``client: {name, email}`` (payer details captured at
+	checkout). Bridge payloads have neither; malformed or non-dict payloads
+	yield blanks.
+	"""
+	out = {"username": "", "name": "", "email": ""}
+	if not raw_payload_json:
+		return out
+	payload = raw_payload_json
+	if isinstance(payload, str):
+		try:
+			payload = json.loads(payload)
+		except ValueError:
+			return out
+	if not isinstance(payload, dict):
+		return out
+
+	out["username"] = _clean(payload.get("customReference"))
+	client = payload.get("client")
+	if isinstance(client, dict):
+		out["name"] = _clean(client.get("name"))
+		out["email"] = _clean(client.get("email"))
+	return out
+
+
+def build_payer_fields(payload_identity=None, account_identity=None, customer_info=None):
+	"""Merge account truth + ERP Customer + provider payload into payer_* fields.
+
+	``account_identity`` comes from mongo (username/phone via kratos user),
+	``customer_info`` from the erpParty-linked ERPNext Customer (name/email/
+	mobile), ``payload_identity`` from parse_payload_identity. Any of them may
+	be None/empty — missing sources just leave blanks.
+	"""
+	payload_identity = payload_identity or {}
+	account_identity = account_identity or {}
+	customer_info = customer_info or {}
+	provider_fields = []
+
+	def pick(field, flash_value, provider_value=""):
+		if flash_value:
+			return str(flash_value)
+		if provider_value:
+			provider_fields.append(field)
+			return str(provider_value)
+		return ""
+
+	return {
+		"payer_name": pick("payer_name", customer_info.get("customer_name"), payload_identity.get("name")),
+		"payer_username": pick(
+			"payer_username", account_identity.get("username"), payload_identity.get("username")
+		),
+		"payer_email": pick("payer_email", customer_info.get("email_id"), payload_identity.get("email")),
+		"payer_phone": pick("payer_phone", account_identity.get("phone") or customer_info.get("mobile_no")),
+		"payer_provider_fields": provider_fields,
+	}

--- a/admin_panel/api/transfer_identity_core.py
+++ b/admin_panel/api/transfer_identity_core.py
@@ -61,6 +61,47 @@ def parse_payload_identity(raw_payload_json):
 	return out
 
 
+def collect_lookup_refs(rows):
+	"""Payload identities + mongo lookup refs for a page of audit rows.
+
+	Every row contributes BOTH its account_id and its payload username when
+	present. Collecting the username even when the row has an account_id keeps
+	the merge phase's username fallback (match_account_identity) deterministic
+	when the account_id is stale and resolves nothing — otherwise the fallback
+	would only work when a *different* row on the same page happened to load
+	that username. Still a single mongo query either way.
+
+	Returns (payload_identities, account_refs, usernames): the identity list is
+	parallel to ``rows``; the ref lists are deduped and sorted.
+	"""
+	payload_identities = []
+	account_refs = set()
+	usernames = set()
+	for row in rows:
+		payload_identity = parse_payload_identity(row.get("raw_payload_json"))
+		payload_identities.append(payload_identity)
+		if row.get("account_id"):
+			account_refs.add(str(row["account_id"]))
+		if payload_identity["username"]:
+			usernames.add(payload_identity["username"])
+	return payload_identities, sorted(account_refs), sorted(usernames)
+
+
+def match_account_identity(row, payload_identity, identities):
+	"""Pick one row's account identity from the batch-lookup results.
+
+	The row's account_id match wins; a row whose account_id missed (stale or
+	foreign id) falls back to its own payload username. Returns None when
+	neither resolves.
+	"""
+	account_identity = None
+	if row.get("account_id"):
+		account_identity = identities.get(str(row["account_id"]))
+	if account_identity is None and (payload_identity or {}).get("username"):
+		account_identity = identities.get(payload_identity["username"])
+	return account_identity
+
+
 def build_payer_fields(payload_identity=None, account_identity=None, customer_info=None):
 	"""Merge account truth + ERP Customer + provider payload into payer_* fields.
 

--- a/admin_panel/tests/test_transfer_identity_core.py
+++ b/admin_panel/tests/test_transfer_identity_core.py
@@ -1,0 +1,114 @@
+"""Unit tests for the pure payer-identity resolution logic.
+
+Fygaro payload shape mirrors real webhook payloads: ``customReference`` is the
+Flash username the app sent with the payment, ``client`` is what the payer
+typed at checkout. Bridge payloads have neither field.
+"""
+
+import json
+
+from admin_panel.api.transfer_identity_core import (
+	PAYER_FIELDS,
+	build_payer_fields,
+	empty_payer_fields,
+	parse_payload_identity,
+)
+
+FYGARO_PAYLOAD = json.dumps(
+	{
+		"amount": 50,
+		"currency": "USD",
+		"customReference": "hotsteppa",
+		"client": {"name": "Jane Doe", "email": "jane@example.com"},
+	}
+)
+
+BRIDGE_PAYLOAD = json.dumps(
+	{
+		"id": "9a1f8c2e",
+		"on_behalf_of": "cust_123",
+		"source": {"payment_rail": "polygon"},
+	}
+)
+
+
+def test_parse_payload_extracts_fygaro_identity():
+	assert parse_payload_identity(FYGARO_PAYLOAD) == {
+		"username": "hotsteppa",
+		"name": "Jane Doe",
+		"email": "jane@example.com",
+	}
+
+
+def test_parse_payload_bridge_rows_yield_blanks():
+	assert parse_payload_identity(BRIDGE_PAYLOAD) == {"username": "", "name": "", "email": ""}
+
+
+def test_parse_payload_never_raises_on_garbage():
+	for garbage in (None, "", "not json", "[1, 2]", '"a string"', json.dumps({"client": "x"}), 42):
+		out = parse_payload_identity(garbage)
+		assert out == {"username": "", "name": "", "email": ""}
+
+
+def test_account_truth_wins_over_provider_payload():
+	fields = build_payer_fields(
+		payload_identity=parse_payload_identity(FYGARO_PAYLOAD),
+		account_identity={"username": "hotsteppa", "phone": "+18765550100", "erp_party": "CUST-1"},
+		customer_info={"customer_name": "Jane A. Doe", "email_id": "jane@flash.com", "mobile_no": ""},
+	)
+	assert fields["payer_username"] == "hotsteppa"
+	assert fields["payer_name"] == "Jane A. Doe"
+	assert fields["payer_email"] == "jane@flash.com"
+	assert fields["payer_phone"] == "+18765550100"
+	assert fields["payer_provider_fields"] == []
+
+
+def test_provider_fallback_is_labeled():
+	fields = build_payer_fields(payload_identity=parse_payload_identity(FYGARO_PAYLOAD))
+	assert fields["payer_username"] == "hotsteppa"
+	assert fields["payer_name"] == "Jane Doe"
+	assert fields["payer_email"] == "jane@example.com"
+	assert fields["payer_phone"] == ""
+	assert sorted(fields["payer_provider_fields"]) == [
+		"payer_email",
+		"payer_name",
+		"payer_username",
+	]
+
+
+def test_mixed_sources_label_only_provider_fields():
+	# Account resolved via customReference but no ERP customer: username/phone
+	# come from Flash, name/email fall back to the checkout form.
+	fields = build_payer_fields(
+		payload_identity=parse_payload_identity(FYGARO_PAYLOAD),
+		account_identity={"username": "hotsteppa", "phone": "+18765550100", "erp_party": None},
+	)
+	assert fields["payer_username"] == "hotsteppa"
+	assert fields["payer_phone"] == "+18765550100"
+	assert fields["payer_name"] == "Jane Doe"
+	assert sorted(fields["payer_provider_fields"]) == ["payer_email", "payer_name"]
+
+
+def test_missing_account_degrades_to_blanks():
+	fields = build_payer_fields(payload_identity=parse_payload_identity(BRIDGE_PAYLOAD))
+	for field in PAYER_FIELDS:
+		assert fields[field] == ""
+	assert fields["payer_provider_fields"] == []
+
+
+def test_phone_falls_back_to_erp_customer_mobile():
+	fields = build_payer_fields(
+		account_identity={"username": "hotsteppa", "phone": None, "erp_party": "CUST-1"},
+		customer_info={"customer_name": "Jane A. Doe", "email_id": None, "mobile_no": "+18765550199"},
+	)
+	assert fields["payer_phone"] == "+18765550199"
+	assert fields["payer_provider_fields"] == []
+
+
+def test_empty_payer_fields_shape_matches_build_output():
+	empty = empty_payer_fields()
+	built = build_payer_fields()
+	assert set(empty) == set(built)
+	for field in PAYER_FIELDS:
+		assert empty[field] == ""
+	assert empty["payer_provider_fields"] == []

--- a/admin_panel/tests/test_transfer_identity_core.py
+++ b/admin_panel/tests/test_transfer_identity_core.py
@@ -10,7 +10,9 @@ import json
 from admin_panel.api.transfer_identity_core import (
 	PAYER_FIELDS,
 	build_payer_fields,
+	collect_lookup_refs,
 	empty_payer_fields,
+	match_account_identity,
 	parse_payload_identity,
 )
 
@@ -48,6 +50,57 @@ def test_parse_payload_never_raises_on_garbage():
 	for garbage in (None, "", "not json", "[1, 2]", '"a string"', json.dumps({"client": "x"}), 42):
 		out = parse_payload_identity(garbage)
 		assert out == {"username": "", "name": "", "email": ""}
+
+
+def test_collect_lookup_refs_collects_username_even_when_row_has_account_id():
+	# Regression: an `elif` here once skipped the payload username whenever the
+	# row carried an account_id, making stale-account_id enrichment depend on
+	# which other rows shared the page.
+	payload_identities, account_refs, usernames = collect_lookup_refs(
+		[{"account_id": "stale-ref", "raw_payload_json": FYGARO_PAYLOAD}]
+	)
+	assert payload_identities == [{"username": "hotsteppa", "name": "Jane Doe", "email": "jane@example.com"}]
+	assert account_refs == ["stale-ref"]
+	assert usernames == ["hotsteppa"]
+
+
+def test_collect_lookup_refs_dedupes_sorts_and_stays_parallel():
+	rows = [
+		{"account_id": "bbb", "raw_payload_json": FYGARO_PAYLOAD},
+		{"account_id": "aaa"},
+		{"account_id": "bbb"},
+		{"raw_payload_json": FYGARO_PAYLOAD},
+		{"raw_payload_json": BRIDGE_PAYLOAD},
+		{},
+	]
+	payload_identities, account_refs, usernames = collect_lookup_refs(rows)
+	assert len(payload_identities) == len(rows)
+	assert account_refs == ["aaa", "bbb"]
+	assert usernames == ["hotsteppa"]
+
+
+def test_match_stale_account_id_falls_back_to_own_payload_username():
+	# Mongo resolved nothing for the stale account_id but keyed the account by
+	# username — the row must still enrich, even alone on the page.
+	identity = {"account_id": "652f", "username": "hotsteppa", "phone": "+18765550100", "erp_party": None}
+	row = {"account_id": "stale-ref", "raw_payload_json": FYGARO_PAYLOAD}
+	payload_identities, _account_refs, _usernames = collect_lookup_refs([row])
+	assert match_account_identity(row, payload_identities[0], {"hotsteppa": identity}) is identity
+
+
+def test_match_prefers_account_id_over_payload_username():
+	by_account = {"account_id": "acct-1", "username": "real-owner"}
+	by_username = {"account_id": "acct-2", "username": "hotsteppa"}
+	identities = {"acct-1": by_account, "hotsteppa": by_username}
+	assert (
+		match_account_identity({"account_id": "acct-1"}, {"username": "hotsteppa"}, identities) is by_account
+	)
+
+
+def test_match_returns_none_when_nothing_resolves():
+	assert match_account_identity({"account_id": "stale-ref"}, {"username": "ghost"}, {}) is None
+	assert match_account_identity({}, {"username": ""}, {"hotsteppa": {"username": "hotsteppa"}}) is None
+	assert match_account_identity({}, None, {"hotsteppa": {"username": "hotsteppa"}}) is None
 
 
 def test_account_truth_wins_over_provider_payload():

--- a/admin_panel/tests/test_transfer_requests_page_contract.py
+++ b/admin_panel/tests/test_transfer_requests_page_contract.py
@@ -169,13 +169,24 @@ def test_audit_rows_carry_payer_identity_and_search_covers_raw_payload():
 	assert "_attach_payer_identity([dict(record) for record in records])" in api_py
 	assert "load_payer_identities" in api_py
 	assert "build_payer_fields" in api_py
+	# Ref collection and identity matching are pure + unit-tested in
+	# transfer_identity_core, not hand-rolled in the IO layer.
+	assert "collect_lookup_refs" in api_py
+	assert "match_account_identity" in api_py
 	assert '["raw_payload_json", "like", like_query]' in api_py
 
 
 def test_audit_table_and_detail_drawer_render_payer_identity():
 	js = read_text(PAGE_DIR / "transfer_requests.js")
 
-	assert "req.payer_username || req.payer_name" in js
+	# The table's Payer column must go through payerValue so provider-sourced
+	# (unverified checkout) values are labeled in the table, not only the drawer.
+	normalized = " ".join(js.split())
+	assert (
+		'const payerDisplay = this.payerValue(req, "payer_username") || '
+		'this.payerValue(req, "payer_name") || "-"' in normalized
+	)
+	assert "req.payer_username || req.payer_name" not in js
 	assert "payerValue(req, field, format)" in js
 	for field in ("payer_name", "payer_username", "payer_email", "payer_phone"):
 		assert f'this.payerValue(req, "{field}"' in js

--- a/admin_panel/tests/test_transfer_requests_page_contract.py
+++ b/admin_panel/tests/test_transfer_requests_page_contract.py
@@ -101,8 +101,14 @@ def test_transfer_requests_bridge_tab_stays_read_only_without_actions_column():
 
 	assert "const cashoutHeaders" in js
 	assert "const bridgeHeaders" in js
-	assert 'const headers = this.active_type === "bridge" ? bridgeHeaders : cashoutHeaders' in js
-	assert 'const bridgeHeaders = ["Request ID", "Type", "Amount", "Status", "Failure", "Last Seen"]' in js
+	# Both audit tabs (Bridge + Card Top-Ups) share bridgeHeaders; only the
+	# cashout tab gets the actions column.
+	assert 'const headers = this.active_type !== "cashout" ? bridgeHeaders : cashoutHeaders' in js
+	normalized = " ".join(js.split())
+	assert (
+		'const bridgeHeaders = [ "Request ID", "Payer", "Type", "Amount", "Status", "Failure", "Last Seen", ]'
+		in normalized
+	)
 
 
 def test_admin_api_exposes_cashout_action_endpoints():
@@ -154,3 +160,23 @@ def test_cashout_details_render_remarks_from_cashout_record():
 	assert '<span class="detail-label">Remarks</span>' in js
 	assert "detail-remarks" in js
 	assert 'panel.find(".detail-remarks").text(req.remarks || "-")' in js
+
+
+def test_audit_rows_carry_payer_identity_and_search_covers_raw_payload():
+	api_py = read_text(ADMIN_PANEL / "api" / "admin_api.py")
+
+	assert "def _attach_payer_identity" in api_py
+	assert "_attach_payer_identity([dict(record) for record in records])" in api_py
+	assert "load_payer_identities" in api_py
+	assert "build_payer_fields" in api_py
+	assert '["raw_payload_json", "like", like_query]' in api_py
+
+
+def test_audit_table_and_detail_drawer_render_payer_identity():
+	js = read_text(PAGE_DIR / "transfer_requests.js")
+
+	assert "req.payer_username || req.payer_name" in js
+	assert "payerValue(req, field, format)" in js
+	for field in ("payer_name", "payer_username", "payer_email", "payer_phone"):
+		assert f'this.payerValue(req, "{field}"' in js
+	assert "(from provider)" in js


### PR DESCRIPTION
## Problem

The Bridge and Card Top-Ups audit tabs on the Transfer Requests page list `Bridge Transfer Request` rows with only request_id/type/amount/status — the operator cannot tell **who** made a top-up.

## What this does

Every audit row returned by `get_bridge_transfer_requests` now carries four new fields: **`payer_name`**, **`payer_username`**, **`payer_email`**, **`payer_phone`** (plus `payer_provider_fields`, the list of values that fell back to the provider payload).

### Data sources (priority order)

1. **Flash account truth** — `account_id` (mongo `_id` or account uuid, both accepted, same handles `find_account` takes) or, when unset, the Fygaro `customReference` username resolves the mongo account. Username comes from `accounts.username`, phone from `users.phone` via `kratosUserId` — the same joins `mongo_reader.customer_bundle` already uses for the Account Hub.
2. **ERPNext Customer via `erpParty`** — the account's `erpParty` (verified present on the flash mongo account schema) links to the Customer doctype for `customer_name` / `email_id` / `mobile_no`, the same fields `_enrich_cashout` already reads for the Cashouts tab.
3. **Fygaro payload fallback** — `customReference` + `client.name` / `client.email` from `raw_payload_json`. These are unverified checkout input, so they are listed in `payer_provider_fields` and the drawer labels them "(from provider)".

### Batch lookups — no N+1

Per page (page_size ≤ 100): **one** mongo `accounts` query (`$or` over `_id` / `id` / `username` `$in` lists) + **one** `users` query for phones (`mongo_reader.load_payer_identities`), then **one** `frappe.get_all("Customer")` for the page's erpParties. Any lookup failure is logged and leaves the payer fields blank — the page never breaks.

### UI

- New **Payer** column on both audit tabs (username, falling back to name), escaped via `escapeHtml`.
- New **Payer** section in the detail drawer: Full Name / Username / Email / Phone, provider-sourced values labeled "(from provider)".
- The page search box now also matches `raw_payload_json`, so searching a username or email finds Fygaro rows whose payment was never attributed.

### Tests

- New `admin_panel/tests/test_transfer_identity_core.py` — pure-logic coverage (Fygaro/Bridge/garbage payload parsing, account-wins priority, provider labeling, missing-account grace), mirroring the `census_core`/`bridge_kyc_core` pattern; the merge/parse logic lives frappe-free in `admin_panel/api/transfer_identity_core.py`.
- Page contract test extended for the new column, drawer section, and search filter. Also fixes two assertions PR #60 left stale (`bridgeHeaders` list, tab ternary) — the file now passes again.

All 150 tests pass; ruff 0.8.1 + prettier 2.7.1 clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcEjF6SS3Ci5D4CzZqdPjb