### PR TITLE
feat(system-accounts): Treasury Funding — fund role wallets via Lightning

### DIFF
--- a/admin_panel/admin_panel/doctype/system_funding_log/system_funding_log.json
+++ b/admin_panel/admin_panel/doctype/system_funding_log/system_funding_log.json
@@ -1,0 +1,95 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "format:SFL-{YYYY}-{#####}",
+ "creation": "2026-08-13 18:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "wallet",
+  "role",
+  "amount_usd",
+  "currency",
+  "memo",
+  "column_break_1",
+  "initiated_by",
+  "ibex_payment_hash"
+ ],
+ "fields": [
+  {
+   "fieldname": "wallet",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Wallet (IBEX id)",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "role",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "System Role",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amount_usd",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Amount (USD)",
+   "precision": "2",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "memo",
+   "fieldtype": "Data",
+   "label": "Memo",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "initiated_by",
+   "fieldtype": "Data",
+   "label": "Initiated By",
+   "read_only": 1
+  },
+  {
+   "fieldname": "ibex_payment_hash",
+   "fieldtype": "Data",
+   "label": "IBEX Payment Hash",
+   "read_only": 1
+  }
+ ],
+ "in_create": 1,
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-13 18:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Admin Panel",
+ "name": "System Funding Log",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "role": "System Manager"
+  },
+  {
+   "read": 1,
+   "role": "Accounts Manager"
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/admin_panel/admin_panel/doctype/system_funding_log/system_funding_log.py
+++ b/admin_panel/admin_panel/doctype/system_funding_log/system_funding_log.py
@@ -1,0 +1,13 @@
+# Append-only treasury funding audit trail. Rows are created exclusively by
+# api/system_accounts.create_funding_invoice (financial-gated) — one row per
+# Lightning receive invoice generated on a treasury (role) wallet. in_create
+# hides the desk "New" button, and no role has write/create/delete permission
+# on purpose. It also exists so audit_log() has a real record to reference: the
+# audit Comment's reference_name is a Dynamic Link and only persists against an
+# existing doctype row.
+
+from frappe.model.document import Document
+
+
+class SystemFundingLog(Document):
+	pass

--- a/admin_panel/admin_panel/page/system_accounts/system_accounts.js
+++ b/admin_panel/admin_panel/page/system_accounts/system_accounts.js
@@ -14,6 +14,7 @@ const SA_ROLE_LABELS = {
 	bankowner: "BankOwner",
 	funder: "Funder",
 	dealer: "Dealer",
+	rewards: "Rewards",
 	watchlist: "Watchlist",
 };
 
@@ -99,6 +100,8 @@ const SA_CSS = `
     .system-accounts .sa-chip.role-funder { background: var(--sa-accent-soft); color: var(--sa-accent-ink); }
     .system-accounts .sa-chip.role-dealer { background: var(--sa-accent-soft); color: var(--sa-accent-ink);
         opacity: 0.85; }
+    .system-accounts .sa-chip.role-rewards { background: var(--sa-accent-soft); color: var(--sa-accent-ink);
+        opacity: 0.7; }
     .system-accounts .sa-chip.st-ok { background: var(--sa-accent-soft); color: var(--sa-accent-ink); }
     .system-accounts .sa-chip.st-bad { background: var(--sa-serious-bg); color: var(--sa-serious); }
     .system-accounts .sa-chip.cur { background: var(--sa-line-soft); color: var(--sa-ink2); }

--- a/admin_panel/admin_panel/page/system_accounts/system_accounts.js
+++ b/admin_panel/admin_panel/page/system_accounts/system_accounts.js
@@ -259,6 +259,13 @@ class SystemAccounts {
 									w.wallet_id
 								)}</span>
                         <span class="sa-spacer"></span>
+                        ${
+							(w.currency === "USD" || w.currency === "USDT") && !w.not_found
+								? `<button class="sa-btn sa-fund-btn" data-wallet="${saEsc(
+										w.wallet_id
+								  )}">Fund</button>`
+								: ""
+						}
                         <button class="sa-btn sa-activity-btn" data-wallet="${saEsc(
 							w.wallet_id
 						)}">Activity</button>
@@ -318,6 +325,9 @@ class SystemAccounts {
 
 		this.page.main.find(".sa-activity-btn").on("click", (e) => {
 			this.toggle_activity($(e.currentTarget).data("wallet"));
+		});
+		this.page.main.find(".sa-fund-btn").on("click", (e) => {
+			this.open_fund_dialog($(e.currentTarget).data("wallet"));
 		});
 		this.page.main.find(".sa-toggle-btn").on("click", (e) => {
 			const btn = $(e.currentTarget);
@@ -565,5 +575,160 @@ class SystemAccounts {
 				this.load();
 			},
 		});
+	}
+
+	wallet_meta(walletId) {
+		for (const acc of this.data?.accounts || []) {
+			for (const w of acc.wallets) {
+				if (w.wallet_id === walletId) return { w, role: acc.role, username: acc.username };
+			}
+		}
+		return null;
+	}
+
+	// Fund a system wallet: generate a Lightning receive invoice the operator
+	// pays from any wallet. No treasury funds move here — money comes IN.
+	open_fund_dialog(walletId) {
+		const meta = this.wallet_meta(walletId);
+		if (!meta) return;
+		const { w, role, username } = meta;
+		const roleLabel = SA_ROLE_LABELS[role] || role;
+		const d = new frappe.ui.Dialog({
+			title: `Fund ${roleLabel} · ${w.currency}`,
+			fields: [
+				{
+					fieldname: "amount",
+					fieldtype: "Currency",
+					label: `Amount (${w.currency})`,
+					reqd: 1,
+					description: `Into ${saEsc(username || w.wallet_id)} · ${saEsc(
+						w.wallet_id.slice(0, 8)
+					)}…`,
+				},
+				{ fieldname: "out", fieldtype: "HTML", options: "" },
+			],
+			primary_action_label: "Generate invoice",
+			primary_action: () => {
+				const amount = Number(d.get_value("amount"));
+				if (!amount || !isFinite(amount) || amount <= 0) {
+					frappe.msgprint("Enter a positive amount.");
+					return;
+				}
+				this.generate_funding_invoice(d, w, amount);
+			},
+		});
+		// Baseline is the page-load balance — captured BEFORE any payment, so a
+		// full-amount rise is unambiguous receipt. Timers cleared on close.
+		d._baseline = Number(w.balance || 0);
+		d._timers = [];
+		d._regens = 0;
+		d.onhide = () => (d._timers || []).forEach((t) => clearInterval(t));
+		d.show();
+	}
+
+	generate_funding_invoice(d, w, amount) {
+		const out = d.fields_dict.out.$wrapper;
+		(d._timers || []).forEach((t) => clearInterval(t));
+		d._timers = [];
+		out.html('<div style="padding:8px 0;color:var(--text-muted);">Generating invoice…</div>');
+		frappe.call({
+			method: "admin_panel.api.system_accounts.create_funding_invoice",
+			args: { wallet_id: w.wallet_id, amount_usd: amount, memo: "Treasury funding" },
+			error: () =>
+				out.html(
+					'<div style="padding:8px 0;color:var(--red,#c0392b);">Could not generate an invoice — try again.</div>'
+				),
+			callback: (res) => {
+				const inv = res.message;
+				if (!inv || !inv.bolt11) {
+					out.html(
+						'<div style="padding:8px 0;color:var(--red,#c0392b);">No invoice returned.</div>'
+					);
+					return;
+				}
+				this.render_funding_invoice(d, w, amount, inv);
+			},
+		});
+	}
+
+	render_funding_invoice(d, w, amount, inv) {
+		const out = d.fields_dict.out.$wrapper;
+		const bolt11 = inv.bolt11;
+		const fmt = (n) =>
+			Number(n).toLocaleString(undefined, {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
+			});
+		out.html(`
+			<div style="border:1px solid var(--border-color);border-radius:10px;padding:12px;margin-top:4px;">
+				<div style="font-size:13px;color:var(--text-muted);margin-bottom:6px;">
+					Pay <strong>$${fmt(inv.amount_usd || amount)} ${saEsc(
+			inv.currency || w.currency
+		)}</strong> from any Lightning wallet. Scanning from a phone pays atomically and beats the 60s expiry.
+				</div>
+				<textarea readonly style="width:100%;height:64px;font-family:var(--font-mono,monospace);font-size:11px;resize:none;padding:6px;border:1px solid var(--border-color);border-radius:8px;background:var(--control-bg,#f7f7f7);">${saEsc(
+					bolt11
+				)}</textarea>
+				<div style="display:flex;gap:8px;align-items:center;margin-top:8px;flex-wrap:wrap;">
+					<button class="btn btn-xs btn-default sa-copy">Copy invoice</button>
+					<a class="btn btn-xs btn-default" href="lightning:${saEsc(bolt11)}">Open in wallet</a>
+					<button class="btn btn-xs btn-default sa-regen">Regenerate</button>
+					<span class="sa-countdown" style="font-size:12px;color:var(--text-muted);"></span>
+				</div>
+				<div class="sa-fund-status" style="margin-top:10px;font-size:13px;font-weight:600;color:var(--text-muted);">
+					Waiting for payment…
+				</div>
+			</div>
+		`);
+		out.find(".sa-copy").on("click", () => {
+			navigator.clipboard?.writeText(bolt11).then(
+				() => frappe.show_alert({ message: "Invoice copied.", indicator: "green" }, 3),
+				() => frappe.msgprint("Copy failed — select and copy manually.")
+			);
+		});
+		out.find(".sa-regen").on("click", () => this.generate_funding_invoice(d, w, amount));
+
+		// Countdown to expiry, auto-regenerating a bounded number of times so a
+		// slow scan isn't stranded; after that the manual Regenerate stays.
+		const expiryMs = inv.expiry_utc ? Date.parse(inv.expiry_utc) : Date.now() + 60000;
+		const cd = out.find(".sa-countdown");
+		const tick = setInterval(() => {
+			const left = Math.round((expiryMs - Date.now()) / 1000);
+			if (left > 0) {
+				cd.text(`expires in ${left}s`);
+			} else {
+				clearInterval(tick);
+				if ((d._regens || 0) < 15) {
+					d._regens = (d._regens || 0) + 1;
+					this.generate_funding_invoice(d, w, amount);
+				} else {
+					cd.text("expired — click Regenerate to keep funding");
+				}
+			}
+		}, 1000);
+		d._timers.push(tick);
+
+		// Receipt poll: a fixed-amount LN invoice settles in full, so the wallet
+		// balance rises by `amount`. Require the full rise to avoid false hits.
+		const poll = setInterval(() => {
+			frappe.call({
+				method: "admin_panel.api.system_accounts.get_system_wallet_balance",
+				args: { wallet_id: w.wallet_id },
+				callback: (res) => {
+					const bal = Number(res.message?.balance);
+					if (!isFinite(bal)) return;
+					if (bal - (d._baseline || 0) >= amount - 0.01) {
+						(d._timers || []).forEach((t) => clearInterval(t));
+						d._timers = [];
+						out.find(".sa-fund-status")
+							.css("color", "var(--green,#0ca30c)")
+							.html(`✓ Received — balance is now $${fmt(bal)}`);
+						frappe.show_alert({ message: "Funding received.", indicator: "green" }, 6);
+						this.load();
+					}
+				},
+			});
+		}, 6000);
+		d._timers.push(poll);
 	}
 }

--- a/admin_panel/admin_panel/page/system_accounts/system_accounts.js
+++ b/admin_panel/admin_panel/page/system_accounts/system_accounts.js
@@ -18,6 +18,14 @@ const SA_ROLE_LABELS = {
 	watchlist: "Watchlist",
 };
 
+// How often the funding receipt poll checks THIS invoice's settlement at IBEX.
+const SA_FUND_POLL_INTERVAL_MS = 6000;
+// The receipt poll stops this long after the Fund dialog opens, so an operator
+// who generates an invoice and walks away can't leave it hammering the backend
+// forever. Roughly matches the ~15 auto-regenerations (15 × 60s). The manual
+// Regenerate / Refresh controls still work after it stops.
+const SA_FUND_POLL_MAX_MS = 15 * 60 * 1000;
+
 function saEsc(v) {
 	return frappe.utils.escape_html(String(v == null ? "" : v));
 }
@@ -620,11 +628,13 @@ class SystemAccounts {
 				this.generate_funding_invoice(d, w, amount);
 			},
 		});
-		// Baseline is the page-load balance — captured BEFORE any payment, so a
-		// full-amount rise is unambiguous receipt. Timers cleared on close.
-		d._baseline = Number(w.balance || 0);
+		// Receipt is confirmed by polling THIS invoice's settlement at IBEX (by
+		// payment hash), never by a wallet-balance delta — the treasury wallets
+		// transact constantly, so a balance rise is not proof of this payment.
+		// The poll is bounded (SA_FUND_POLL_MAX_MS) and all timers clear on close.
 		d._timers = [];
 		d._regens = 0;
+		d._pollDeadline = Date.now() + SA_FUND_POLL_MAX_MS;
 		d.onhide = () => (d._timers || []).forEach((t) => clearInterval(t));
 		d.show();
 	}
@@ -711,27 +721,57 @@ class SystemAccounts {
 		}, 1000);
 		d._timers.push(tick);
 
-		// Receipt poll: a fixed-amount LN invoice settles in full, so the wallet
-		// balance rises by `amount`. Require the full rise to avoid false hits.
+		// Receipt: confirm THIS invoice settled at IBEX, looked up by its payment
+		// hash — never a wallet-balance delta. The bankowner float grows with
+		// every cashout, so a balance rise cannot be sold as receipt of this
+		// funding payment. If the backend didn't return a hash we can't confirm
+		// automatically, so show a neutral note instead of a false ✓.
+		const invoiceHash = inv.hash;
+		const statusEl = out.find(".sa-fund-status");
+		if (!invoiceHash) {
+			statusEl.html(
+				"Waiting for payment… (auto-confirmation unavailable — use Refresh to check the balance)"
+			);
+			return;
+		}
 		const poll = setInterval(() => {
+			// Bound the poll so an abandoned dialog can't hit the backend forever.
+			if (Date.now() > (d._pollDeadline || 0)) {
+				(d._timers || []).forEach((t) => clearInterval(t));
+				d._timers = [];
+				statusEl.html(
+					"Stopped checking — click Regenerate or Refresh if you're still funding."
+				);
+				return;
+			}
 			frappe.call({
-				method: "admin_panel.api.system_accounts.get_system_wallet_balance",
-				args: { wallet_id: w.wallet_id },
+				method: "admin_panel.api.system_accounts.get_funding_invoice_status",
+				args: { invoice_hash: invoiceHash },
 				callback: (res) => {
-					const bal = Number(res.message?.balance);
-					if (!isFinite(bal)) return;
-					if (bal - (d._baseline || 0) >= amount - 0.01) {
-						(d._timers || []).forEach((t) => clearInterval(t));
-						d._timers = [];
-						out.find(".sa-fund-status")
-							.css("color", "var(--green,#0ca30c)")
-							.html(`✓ Received — balance is now $${fmt(bal)}`);
-						frappe.show_alert({ message: "Funding received.", indicator: "green" }, 6);
-						this.load();
-					}
+					// settled is True ONLY on an affirmative IBEX SETTLED state;
+					// open/ambiguous keeps us waiting (never claim receipt on a guess).
+					if (!res.message || res.message.settled !== true) return;
+					(d._timers || []).forEach((t) => clearInterval(t));
+					d._timers = [];
+					statusEl
+						.css("color", "var(--green,#0ca30c)")
+						.html("✓ Received — payment settled");
+					// One-shot fresh balance for the confirmation line (NOT polled).
+					frappe.call({
+						method: "admin_panel.api.system_accounts.get_system_wallet_balance",
+						args: { wallet_id: w.wallet_id },
+						callback: (b) => {
+							const bal = Number(b.message?.balance);
+							if (isFinite(bal)) {
+								statusEl.html(`✓ Received — balance is now $${fmt(bal)}`);
+							}
+						},
+					});
+					frappe.show_alert({ message: "Funding received.", indicator: "green" }, 6);
+					this.load();
 				},
 			});
-		}, 6000);
+		}, SA_FUND_POLL_INTERVAL_MS);
 		d._timers.push(poll);
 	}
 }

--- a/admin_panel/api/census_core.py
+++ b/admin_panel/api/census_core.py
@@ -11,7 +11,7 @@ depend on the constants and `build_census` defined here.
 CURRENCY_BY_ID = {3: "Usd", 29: "Usdt"}
 
 # Account roles that are Flash-internal system accounts, not real customers.
-SYSTEM_ROLES = {"dealer", "bankowner", "funder"}
+SYSTEM_ROLES = {"dealer", "bankowner", "funder", "rewards"}
 
 # Account status (last statusHistory entry) considered "active", case-insensitive.
 ACTIVE_STATUS = "active"

--- a/admin_panel/api/ibex_client.py
+++ b/admin_panel/api/ibex_client.py
@@ -159,8 +159,21 @@ class IbexClient:
 		"""POST with the same raw-token auth + 401/429 handling as _get.
 
 		Only the two treasury calls below use this — the client is otherwise
-		read-only by design. Never add a write here without a matching
-		System-Manager-gated endpoint and a System Transfer Log record.
+		read-only by design.
+
+		Write policy — two deliberately different tiers:
+		  * VALUE-MOVING writes (pay_invoice, and add_invoice used as the
+		    receiver leg of a wallet-to-wallet transfer) move treasury funds and
+		    require a System-Manager-gated endpoint plus a System Transfer Log
+		    record (see transfer_between_system_wallets).
+		  * INBOUND-ONLY receive-invoice creation (add_invoice called on its own
+		    so an external payer can fund a wallet — create_funding_invoice) moves
+		    NO treasury money on creation; the payer's later payment only credits
+		    us. It is therefore financial-gated (System Manager OR Accounts
+		    Manager), bounded by a fat-finger cap, and audit_log'd rather than
+		    Transfer-Log'd. Do NOT widen this carve-out to any write that debits a
+		    system wallet.
+		Never add a NEW write here without matching one of these two tiers.
 		"""
 		url = f"{self.hub_url}{path}"
 		headers = {"Authorization": self._get_token()}
@@ -198,6 +211,26 @@ class IbexClient:
 		cutover code uses for treasury moves.
 		"""
 		resp = self._post("/v2/invoice/pay", {"accountId": account_id, "bolt11": bolt11})
+		return resp.json()
+
+	def get_invoice_from_hash(self, invoice_hash: str) -> dict:
+		"""Look up ONE invoice by its payment hash: GET /invoice/from-hash/{hash}.
+
+		Read-only. Used by the funding receipt poll to confirm THIS specific
+		invoice settled at IBEX — never a wallet-balance delta, which on an
+		actively-transacting treasury wallet (bankowner's float grows with every
+		cashout) would misread routine inflow as the funding payment.
+
+		A 404 means the hub does not (yet) know the hash — returned as
+		{not_found: True} so the poll keeps waiting instead of erroring. Note the
+		path has no /v2 prefix (the hub serves from-hash under /invoice/...),
+		matching the ibex-client library and the flash backend's settle verifier.
+		The settled state lives at response state.id == 1 (SETTLED); see
+		ibex_status.invoice_settled.
+		"""
+		resp = self._get(f"/invoice/from-hash/{invoice_hash}", {}, allow_not_found=True)
+		if resp.status_code == 404:
+			return {"hash": invoice_hash, "not_found": True}
 		return resp.json()
 
 	def get_account_details(self, account_id: str) -> dict:

--- a/admin_panel/api/ibex_status.py
+++ b/admin_panel/api/ibex_status.py
@@ -1,0 +1,46 @@
+"""Pure interpretation of IBEX invoice settlement state.
+
+IO-free (no frappe / requests / pymongo) so the money-critical "did THIS invoice
+actually settle?" logic can be unit-tested against fixtures with plain pytest —
+the same isolation census_core uses for the census join logic. system_accounts.py
+imports invoice_settled for the funding receipt signal.
+"""
+
+# IBEX invoice states (LND-derived), verified against the flash backend's on-pay
+# settlement verifier (src/services/ibex/webhook-server/routes/on-pay.ts):
+#   0 OPEN / 1 SETTLED / 2 CANCELLED / 3 ACCEPTED
+# Only SETTLED means the receive invoice was actually paid. ACCEPTED (a held
+# HTLC) is NOT money in hand.
+INVOICE_STATE_SETTLED = 1
+INVOICE_STATE_CANCELLED = 2
+
+_SETTLED_NAMES = {"SETTLED", "SUCCEEDED", "COMPLETE", "COMPLETED", "PAID"}
+_FAILED_NAMES = {"CANCELLED", "CANCELED", "EXPIRED", "FAILED"}
+
+
+def _state_id_and_name(invoice):
+	"""(state_id, state_name) from either a nested {state:{id,name}} or a flat
+	stateId shape. Returns (None, "") when neither is present."""
+	state = invoice.get("state")
+	if isinstance(state, dict):
+		return state.get("id"), (state.get("name") or "")
+	return invoice.get("stateId"), ""
+
+
+def invoice_settled(invoice):
+	"""Did THIS invoice affirmatively settle? True / False / None.
+
+	Fail-safe by design (mirrors _payment_settled in system_accounts): an OPEN or
+	ACCEPTED invoice, an unknown/ambiguous shape, or a not-yet-known payment hash
+	all yield None — treated as "still waiting", never as receipt. Money is never
+	reported received on a guess, and never on a mere balance change.
+	"""
+	if not isinstance(invoice, dict) or invoice.get("not_found"):
+		return None
+	state_id, name = _state_id_and_name(invoice)
+	name = (name or "").upper()
+	if state_id == INVOICE_STATE_SETTLED or name in _SETTLED_NAMES:
+		return True
+	if state_id == INVOICE_STATE_CANCELLED or name in _FAILED_NAMES:
+		return False
+	return None

--- a/admin_panel/api/system_accounts.py
+++ b/admin_panel/api/system_accounts.py
@@ -31,6 +31,11 @@ OUTSTANDING_CASHOUT_STATUSES = ("Pending", "Draft", "In Progress")
 # Hard ceiling on a single transfer unless site_config raises it.
 DEFAULT_TRANSFER_CAP_USD = 100.0
 
+# Fat-finger ceiling on a single funding invoice. Funding brings money IN (no
+# treasury outflow), so this is a sanity bound, not a risk limit — generous and
+# separately configurable via site_config system_funding_cap_usd.
+DEFAULT_FUNDING_CAP_USD = 100000.0
+
 CURRENCY_BY_ID = {0: "BTC", 3: "USD", 29: "USDT"}
 
 # IBEX pay-invoice status: 2 = SUCCEEDED (verified against the hub).
@@ -262,6 +267,93 @@ def get_system_account_activity(wallet_id, page=0, limit=20):
 		for tx in raw
 	]
 	return {"wallet_id": wallet_id, "page": page, "transactions": transactions}
+
+
+@frappe.whitelist()
+@require_financial()
+@handle_api_errors
+def create_funding_invoice(wallet_id, amount_usd, memo=None):
+	"""Generate a Lightning receive invoice so an EXTERNAL payer can fund a
+	system wallet (bankowner/funder/dealer) from the page.
+
+	No treasury money moves here — an invoice is created ON the wallet's IBEX
+	account; the payer's Lightning payment credits it directly at IBEX. This is
+	the inbound cousin of transfer_between_system_wallets and reuses the same
+	sanctioned add_invoice (/v2/invoice/add) write — no new IBEX write path.
+
+	Denominated (USD/USDT) IBEX receive invoices are capped at ~60s expiry by
+	the hub, so the page counts down and regenerates — expiry_utc is returned
+	for that. Returns only display fields, never the raw IBEX response.
+	"""
+	wallet_id = frappe.utils.cstr(wallet_id)
+	try:
+		amount = float(amount_usd)
+	except (TypeError, ValueError):
+		frappe.throw("Amount must be a number")
+	# math.isfinite rejects NaN/inf, which slip past `amount > cap` (NaN
+	# comparisons are always False) and would reach IBEX.
+	if not math.isfinite(amount) or amount <= 0:
+		frappe.throw("Amount must be a positive number")
+	cap = float(frappe.conf.get("system_funding_cap_usd") or DEFAULT_FUNDING_CAP_USD)
+	if amount > cap:
+		frappe.throw(f"Amount exceeds the funding cap of ${cap:,.2f} (site_config system_funding_cap_usd)")
+
+	# Membership re-derived server-side — never a generate-invoice-for-any-wallet
+	# proxy.
+	wallet = None
+	for acc in _resolve_system_accounts():
+		for w in acc["wallets"]:
+			if w["wallet_id"] == wallet_id:
+				wallet = {**w, "role": acc["role"]}
+				break
+		if wallet:
+			break
+	if not wallet:
+		frappe.throw("Not a system-account wallet", frappe.PermissionError)
+	# A denominated invoice on a BTC (sats) wallet means a different unit; the
+	# page only offers Fund on USD/USDT rows, but guard the backend too.
+	if (wallet.get("mongo_currency") or "").upper() == "BTC":
+		frappe.throw("Funding invoices are USD/USDT only (BTC wallets use a different rail).")
+
+	memo = frappe.utils.cstr(memo or "Treasury funding")
+	# expiration=60 requests the hub's max window for a denominated invoice.
+	invoice = IbexClient().add_invoice(wallet_id, amount, memo=memo, expiration=60)
+	inv = invoice.get("invoice") or {}
+	bolt11 = inv.get("bolt11")
+	if not bolt11:
+		raise ValueError(f"IBEX add_invoice returned no bolt11: {str(invoice)[:200]}")
+	currency = (
+		CURRENCY_BY_ID.get(invoice.get("currencyId")) or wallet.get("mongo_currency") or "USD"
+	).upper()
+	frappe.logger().info(f"funding_invoice wallet={wallet_id} amount={amount} by={frappe.session.user}")
+	return {
+		"wallet_id": wallet_id,
+		"amount_usd": round(amount, 2),
+		"currency": currency,
+		"bolt11": bolt11,
+		"expiry_utc": inv.get("expiryDateUtc"),
+	}
+
+
+@frappe.whitelist()
+@require_financial()
+@handle_api_errors
+def get_system_wallet_balance(wallet_id):
+	"""Live balance for ONE system wallet — a cheap single-wallet read for the
+	funding modal's receipt poll (get_system_accounts fetches every wallet, too
+	heavy to poll). Membership re-derived server-side."""
+	wallet_id = frappe.utils.cstr(wallet_id)
+	known = {w["wallet_id"] for acc in _resolve_system_accounts() for w in acc["wallets"]}
+	if wallet_id not in known:
+		frappe.throw("Not a system-account wallet", frappe.PermissionError)
+	details = IbexClient().get_account_details(wallet_id)
+	currency = (CURRENCY_BY_ID.get(details.get("currencyId")) or "USD").upper()
+	return {
+		"wallet_id": wallet_id,
+		"currency": currency,
+		"balance": float(details.get("balance") or 0.0),
+		"not_found": bool(details.get("not_found")),
+	}
 
 
 @frappe.whitelist()

--- a/admin_panel/api/system_accounts.py
+++ b/admin_panel/api/system_accounts.py
@@ -1,4 +1,4 @@
-"""System accounts treasury: bankowner / funder / dealer live balances,
+"""System accounts treasury: bankowner / funder / dealer / rewards live balances,
 activity, cashout-payables coverage, and gated fund movement.
 
 Money-flow facts this module leans on (verified in the flash codebase):
@@ -23,7 +23,7 @@ from .common import handle_api_errors
 from .ibex_client import IbexClient
 from .mongo_reader import load_accounts, load_wallets
 
-SYSTEM_ROLES = ("bankowner", "funder", "dealer")
+SYSTEM_ROLES = ("bankowner", "funder", "dealer", "rewards")
 
 # Cashouts whose fiat leg has not been paid out yet.
 OUTSTANDING_CASHOUT_STATUSES = ("Pending", "Draft", "In Progress")
@@ -117,7 +117,7 @@ def _watchlist_map():
 def _resolve_system_accounts():
 	"""All role accounts + the watchlist, with their wallets.
 
-	Role accounts (bankowner/funder/dealer) are always transfer-eligible.
+	Role accounts (bankowner/funder/dealer/rewards) are always transfer-eligible.
 	Watchlist accounts are VIEW-ONLY unless their doctype row has
 	allow_transfers set — a deliberate per-account opt-in.
 	"""
@@ -163,8 +163,8 @@ def _resolve_system_accounts():
 				"wallets": sorted(by_account.get(account_id, []), key=lambda w: w["wallet_id"]),
 			}
 		)
-	# bankowner first, then funder, dealer, watchlist
-	order = {"bankowner": 0, "funder": 1, "dealer": 2, "watchlist": 3}
+	# bankowner first, then funder, dealer, rewards, watchlist
+	order = {"bankowner": 0, "funder": 1, "dealer": 2, "rewards": 3, "watchlist": 4}
 	resolved.sort(key=lambda a: (order.get(a["role"], 9), a["username"] or ""))
 	return resolved
 
@@ -274,7 +274,7 @@ def get_system_account_activity(wallet_id, page=0, limit=20):
 @handle_api_errors
 def create_funding_invoice(wallet_id, amount_usd, memo=None):
 	"""Generate a Lightning receive invoice so an EXTERNAL payer can fund a
-	system wallet (bankowner/funder/dealer) from the page.
+	system wallet (bankowner/funder/dealer/rewards) from the page.
 
 	No treasury money moves here — an invoice is created ON the wallet's IBEX
 	account; the payer's Lightning payment credits it directly at IBEX. This is
@@ -360,7 +360,7 @@ def get_system_wallet_balance(wallet_id):
 @require_roles(["System Manager"])
 @handle_api_errors
 def transfer_between_system_wallets(from_wallet_id, to_wallet_id, amount_usd, memo=None):
-	"""Move funds between two ROLE wallets (bankowner/funder/dealer only —
+	"""Move funds between two ROLE wallets (bankowner/funder/dealer/rewards only —
 	watchlist accounts are view-only). add_invoice on the receiver,
 	pay_invoice from the sender; every attempt is a System Transfer Log doc.
 

--- a/admin_panel/api/system_accounts.py
+++ b/admin_panel/api/system_accounts.py
@@ -21,6 +21,7 @@ import requests
 from .auth import audit_log, require_financial, require_roles
 from .common import handle_api_errors
 from .ibex_client import IbexClient
+from .ibex_status import invoice_settled
 from .mongo_reader import load_accounts, load_wallets
 
 SYSTEM_ROLES = ("bankowner", "funder", "dealer", "rewards")
@@ -325,12 +326,25 @@ def create_funding_invoice(wallet_id, amount_usd, memo=None):
 	currency = (
 		CURRENCY_BY_ID.get(invoice.get("currencyId")) or wallet.get("mongo_currency") or "USD"
 	).upper()
+	# The payment hash identifies THIS invoice; the receipt poll confirms its
+	# settlement by hash (get_funding_invoice_status), never by a balance delta.
+	invoice_hash = frappe.utils.cstr(inv.get("hash") or "")
 	frappe.logger().info(f"funding_invoice wallet={wallet_id} amount={amount} by={frappe.session.user}")
+	# Generating an LN invoice on a treasury account is a privileged action —
+	# give it the same traceability trail as transfer_between_system_wallets
+	# (audit_log, not just an app-log line).
+	audit_log(
+		"funding_invoice",
+		"System Wallet",
+		wallet_id,
+		{"amount_usd": round(amount, 2), "currency": currency, "hash": invoice_hash},
+	)
 	return {
 		"wallet_id": wallet_id,
 		"amount_usd": round(amount, 2),
 		"currency": currency,
 		"bolt11": bolt11,
+		"hash": invoice_hash,
 		"expiry_utc": inv.get("expiryDateUtc"),
 	}
 
@@ -338,10 +352,43 @@ def create_funding_invoice(wallet_id, amount_usd, memo=None):
 @frappe.whitelist()
 @require_financial()
 @handle_api_errors
+def get_funding_invoice_status(invoice_hash):
+	"""Settlement status of ONE funding invoice, by its payment hash, read from
+	IBEX (GET /invoice/from-hash) — the funding modal's authoritative receipt
+	signal.
+
+	This confirms the SPECIFIC invoice settled, never a wallet-balance rise: the
+	busiest treasury wallet (bankowner) grows with every cashout, so a balance
+	delta cannot tell this funding payment apart from routine inflow (that false
+	signal is exactly what this endpoint replaces). Membership was already
+	enforced when the invoice was issued (create_funding_invoice re-derives it
+	server-side before generating), so this read is deliberately cheap — one IBEX
+	call, no mongo/account scan — and safe to poll. `settled` is True only on an
+	affirmative IBEX SETTLED state; OPEN / ambiguous / unknown-hash all return
+	False so the UI keeps waiting and never claims receipt on a guess.
+	"""
+	invoice_hash = frappe.utils.cstr(invoice_hash)
+	if not invoice_hash:
+		frappe.throw("Invoice hash is required")
+	invoice = IbexClient().get_invoice_from_hash(invoice_hash)
+	state = invoice.get("state")
+	return {
+		"hash": invoice_hash,
+		"settled": invoice_settled(invoice) is True,
+		"state": state.get("name") if isinstance(state, dict) else None,
+	}
+
+
+@frappe.whitelist()
+@require_financial()
+@handle_api_errors
 def get_system_wallet_balance(wallet_id):
-	"""Live balance for ONE system wallet — a cheap single-wallet read for the
-	funding modal's receipt poll (get_system_accounts fetches every wallet, too
-	heavy to poll). Membership re-derived server-side."""
+	"""Live balance for ONE system wallet. Membership is re-derived server-side
+	via _resolve_system_accounts() (a full accounts+wallets scan), so this is NOT
+	a cheap call and must not be polled in a tight loop. The funding modal calls
+	it ONCE, after get_funding_invoice_status confirms settlement, to show the
+	updated balance in the confirmation line; per-tick receipt polling uses the
+	cheap invoice-status read instead."""
 	wallet_id = frappe.utils.cstr(wallet_id)
 	known = {w["wallet_id"] for acc in _resolve_system_accounts() for w in acc["wallets"]}
 	if wallet_id not in known:

--- a/admin_panel/api/system_accounts.py
+++ b/admin_panel/api/system_accounts.py
@@ -330,37 +330,49 @@ def create_funding_invoice(wallet_id, amount_usd, memo=None):
 	# settlement by hash (get_funding_invoice_status), never by a balance delta.
 	invoice_hash = frappe.utils.cstr(inv.get("hash") or "")
 	frappe.logger().info(f"funding_invoice wallet={wallet_id} amount={amount} by={frappe.session.user}")
-	# Generating an LN invoice on a treasury account is a privileged action —
-	# give it the same traceability trail as transfer_between_system_wallets: a
-	# row in the append-only System Funding Log, one per invoice generated.
-	log = frappe.get_doc(
-		{
-			"doctype": "System Funding Log",
-			"wallet": wallet_id,
-			"role": wallet.get("role"),
-			"amount_usd": round(amount, 2),
-			"currency": currency,
-			"memo": memo,
-			"ibex_payment_hash": invoice_hash,
-			"initiated_by": frappe.session.user,
-		}
-	)
-	log.insert(ignore_permissions=True)
-	# audit_log writes a Frappe Comment whose reference_name is a Dynamic Link —
-	# it only persists against a REAL doctype row (a made-up wallet doctype
-	# reference fails link validation and the entry is silently dropped). Point it
-	# at the System Funding Log row we just inserted.
-	audit_log(
-		"funding_invoice",
-		"System Funding Log",
-		log.name,
-		{
-			"wallet": wallet_id,
-			"amount_usd": round(amount, 2),
-			"currency": currency,
-			"hash": invoice_hash,
-		},
-	)
+	# Generating an LN invoice on a treasury account is a privileged action — give
+	# it the same traceability trail as transfer_between_system_wallets: a row in
+	# the append-only System Funding Log, one per invoice generated.
+	#
+	# BEST-EFFORT: the invoice already exists at IBEX (add_invoice above is
+	# irreversible), so a logging failure must NEVER strand it by hiding the
+	# bolt11. The concrete trigger is the System Funding Log doctype not yet being
+	# migrated on a fresh deploy; a transient DB error is another. Warn and fall
+	# through to return the bolt11 regardless.
+	try:
+		log = frappe.get_doc(
+			{
+				"doctype": "System Funding Log",
+				"wallet": wallet_id,
+				"role": wallet.get("role"),
+				"amount_usd": round(amount, 2),
+				"currency": currency,
+				"memo": memo,
+				"ibex_payment_hash": invoice_hash,
+				"initiated_by": frappe.session.user,
+			}
+		)
+		log.insert(ignore_permissions=True)
+		# audit_log writes a Frappe Comment whose reference_name is a Dynamic Link —
+		# it only persists against a REAL doctype row (a made-up wallet doctype
+		# reference fails link validation and the entry is silently dropped). Point
+		# it at the System Funding Log row we just inserted.
+		audit_log(
+			"funding_invoice",
+			"System Funding Log",
+			log.name,
+			{
+				"wallet": wallet_id,
+				"amount_usd": round(amount, 2),
+				"currency": currency,
+				"hash": invoice_hash,
+			},
+		)
+	except Exception:
+		frappe.logger().warning(
+			f"funding_invoice audit write failed (invoice already issued) "
+			f"wallet={wallet_id} hash={invoice_hash}"
+		)
 	return {
 		"wallet_id": wallet_id,
 		"amount_usd": round(amount, 2),

--- a/admin_panel/api/system_accounts.py
+++ b/admin_panel/api/system_accounts.py
@@ -331,13 +331,35 @@ def create_funding_invoice(wallet_id, amount_usd, memo=None):
 	invoice_hash = frappe.utils.cstr(inv.get("hash") or "")
 	frappe.logger().info(f"funding_invoice wallet={wallet_id} amount={amount} by={frappe.session.user}")
 	# Generating an LN invoice on a treasury account is a privileged action —
-	# give it the same traceability trail as transfer_between_system_wallets
-	# (audit_log, not just an app-log line).
+	# give it the same traceability trail as transfer_between_system_wallets: a
+	# row in the append-only System Funding Log, one per invoice generated.
+	log = frappe.get_doc(
+		{
+			"doctype": "System Funding Log",
+			"wallet": wallet_id,
+			"role": wallet.get("role"),
+			"amount_usd": round(amount, 2),
+			"currency": currency,
+			"memo": memo,
+			"ibex_payment_hash": invoice_hash,
+			"initiated_by": frappe.session.user,
+		}
+	)
+	log.insert(ignore_permissions=True)
+	# audit_log writes a Frappe Comment whose reference_name is a Dynamic Link —
+	# it only persists against a REAL doctype row (a made-up wallet doctype
+	# reference fails link validation and the entry is silently dropped). Point it
+	# at the System Funding Log row we just inserted.
 	audit_log(
 		"funding_invoice",
-		"System Wallet",
-		wallet_id,
-		{"amount_usd": round(amount, 2), "currency": currency, "hash": invoice_hash},
+		"System Funding Log",
+		log.name,
+		{
+			"wallet": wallet_id,
+			"amount_usd": round(amount, 2),
+			"currency": currency,
+			"hash": invoice_hash,
+		},
 	)
 	return {
 		"wallet_id": wallet_id,

--- a/admin_panel/tests/test_census_core.py
+++ b/admin_panel/tests/test_census_core.py
@@ -217,6 +217,39 @@ def test_sweep_pages_empty_first_page():
 	assert list(sweep_pages(lambda p: [], max_pages=5)) == []
 
 
+def test_rewards_role_is_system_not_customer():
+	"""A role='rewards' account is a Flash-internal system account, not a real
+	customer: it must land in the 'system' bucket, be flagged is_system, and
+	never be counted in a customer bucket (active_funded / active_zero /
+	closed_with_dust). Regression for making `rewards` a first-class system role
+	alongside bankowner/funder/dealer — previously only grep-verified."""
+	ibex = [{"id": "w-rw", "name": "acc-rw", "currencyId": 3, "balance": 500.0}]
+	wallets = {"w-rw": {"account_id": "acc-rw", "currency": "Usd", "type": "Checking"}}
+	accounts = {
+		"acc-rw": {
+			"username": "rewards",
+			"role": "rewards",
+			"status": "active",
+			"default_wallet_id": "w-rw",
+			"level": 2,
+		}
+	}
+
+	result = build_census(ibex, wallets, accounts, {})
+	row = result["rows"][0]
+
+	assert row["role"] == "rewards"
+	assert row["is_system"] is True
+	assert row["buckets"] == ["system"]
+
+	counts = result["bucket_counts"]
+	assert counts["system"] == 1
+	# a funded system account must never be miscounted as a customer
+	assert counts["active_funded"] == 0
+	assert counts["active_zero"] == 0
+	assert counts["closed_with_dust"] == 0
+
+
 def test_micro_dust_is_not_funded():
 	"""IBEX emits sub-nanodollar dust (~1e-10 seen on prod): it must classify
 	as zero — 91 rows showed 'active_funded' at $0.00 on the first full census."""

--- a/admin_panel/tests/test_ibex_status.py
+++ b/admin_panel/tests/test_ibex_status.py
@@ -1,0 +1,51 @@
+"""Unit tests for the pure IBEX invoice-settlement interpretation.
+
+This is the money-critical receipt signal for treasury funding: it decides
+whether the UI may tell an operator "the invoice was paid". It replaces the old
+wallet-balance-delta heuristic, which on an actively-transacting treasury wallet
+(bankowner's float grows with every cashout) would falsely read routine inflow
+as the funding payment. The logic is IO-free, so it is tested directly here
+rather than only grepped for in the source.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+	sys.path.insert(0, str(REPO_ROOT))
+
+from admin_panel.api.ibex_status import invoice_settled
+
+
+def test_settled_state_is_receipt():
+	# state.id == 1 is the authoritative SETTLED signal (verified against the
+	# flash backend's on-pay verifier); the flat stateId and the name both work.
+	assert invoice_settled({"state": {"id": 1, "name": "SETTLED"}}) is True
+	assert invoice_settled({"stateId": 1}) is True
+	assert invoice_settled({"state": {"name": "SETTLED"}}) is True
+
+
+def test_open_invoice_is_never_receipt():
+	# The whole point of the fix: an OPEN (unpaid) invoice must NOT read as
+	# settled, even though the wallet's balance may have risen from other traffic.
+	assert invoice_settled({"state": {"id": 0, "name": "OPEN"}}) is None
+
+
+def test_accepted_htlc_is_not_settled():
+	# ACCEPTED (id 3) is a held HTLC, not money in hand — must stay ambiguous.
+	assert invoice_settled({"state": {"id": 3, "name": "ACCEPTED"}}) is None
+
+
+def test_cancelled_or_expired_is_affirmative_failure():
+	assert invoice_settled({"state": {"id": 2, "name": "CANCELLED"}}) is False
+	assert invoice_settled({"state": {"name": "EXPIRED"}}) is False
+
+
+def test_unknown_or_missing_shape_is_ambiguous_not_success():
+	# Fail-safe: a not-yet-known hash, an empty/odd shape, or None all yield None
+	# so receipt is never claimed on a guess.
+	assert invoice_settled({"not_found": True}) is None
+	assert invoice_settled({}) is None
+	assert invoice_settled(None) is None
+	assert invoice_settled({"state": {"id": 99, "name": "WEIRD"}}) is None

--- a/admin_panel/tests/test_system_accounts_page_contract.py
+++ b/admin_panel/tests/test_system_accounts_page_contract.py
@@ -170,8 +170,14 @@ def test_funding_invoice_generation_is_audited():
 	# "System Wallet", which is not a doctype and would fail link validation,
 	# silently dropping the audit entry).
 	assert '"doctype": "System Funding Log"' in API_PY, "must insert a real System Funding Log row"
-	assert '"System Funding Log",\n\t\tlog.name,' in API_PY, "audit_log must reference the inserted row"
+	assert re.search(
+		r'"System Funding Log",\s*\n\s*log\.name,', API_PY
+	), "audit_log must reference the inserted System Funding Log row"
 	assert '"System Wallet"' not in API_PY, "audit must not reference the non-existent System Wallet doctype"
+	# BEST-EFFORT: the invoice already exists at IBEX before we log, so a logging
+	# failure (e.g. the doctype not yet migrated) must never strand the invoice by
+	# hiding its bolt11 — the audit write is wrapped and falls through to return.
+	assert "funding_invoice audit write failed" in API_PY
 
 
 def test_funding_log_doctype_is_append_only():

--- a/admin_panel/tests/test_system_accounts_page_contract.py
+++ b/admin_panel/tests/test_system_accounts_page_contract.py
@@ -16,6 +16,7 @@ IBEX_PY = (ADMIN_PANEL / "api" / "ibex_client.py").read_text()
 PAGE_JS = (ADMIN_PANEL / "admin_panel" / "page" / "system_accounts" / "system_accounts.js").read_text()
 SETUP_PY = (ADMIN_PANEL / "admin_panel" / "setup.py").read_text()
 CENSUS_PY = (ADMIN_PANEL / "api" / "census_core.py").read_text()
+IBEX_STATUS_PY = (ADMIN_PANEL / "api" / "ibex_status.py").read_text()
 
 
 def test_read_endpoints_carry_the_financial_gate():
@@ -129,6 +130,48 @@ def test_wallet_balance_read_is_financial_gated_and_membership_checked():
 	stack = "@frappe.whitelist()\n@require_financial()\n@handle_api_errors\ndef get_system_wallet_balance("
 	assert stack in API_PY
 	assert '"Not a system-account wallet"' in API_PY
+
+
+def test_funding_receipt_is_invoice_settlement_not_balance_delta():
+	# The receipt signal must confirm THIS invoice settled at IBEX (by payment
+	# hash), never infer it from a wallet-balance rise — the bankowner float grows
+	# with every cashout, so a delta cannot distinguish the funding payment from
+	# routine inflow.
+	stack = "@frappe.whitelist()\n@require_financial()\n@handle_api_errors\ndef get_funding_invoice_status("
+	assert stack in API_PY, "get_funding_invoice_status must be whitelisted + financial-gated"
+	# it reads the specific invoice by hash and interprets settlement fail-safe
+	assert "get_invoice_from_hash(" in API_PY
+	assert "invoice_settled(invoice)" in API_PY
+	assert "def get_invoice_from_hash(" in IBEX_PY
+	assert "/invoice/from-hash/" in IBEX_PY
+	# create_funding_invoice returns the payment hash the poll keys on
+	assert '"hash": invoice_hash' in API_PY
+
+	# The page polls settlement, not balance — and the old balance-delta receipt
+	# heuristic is gone (baseline capture + `bal - baseline >= amount`).
+	assert "admin_panel.api.system_accounts.get_funding_invoice_status" in PAGE_JS
+	assert "settled !== true" in PAGE_JS
+	assert "inv.hash" in PAGE_JS
+	assert "d._baseline" not in PAGE_JS, "balance-delta receipt heuristic must be removed"
+	assert "bal - (d._baseline" not in PAGE_JS
+
+	# The poll is bounded so an abandoned Fund dialog can't hammer the backend.
+	assert "SA_FUND_POLL_MAX_MS" in PAGE_JS
+	assert "_pollDeadline" in PAGE_JS
+
+
+def test_funding_invoice_generation_is_audited():
+	# Generating an LN invoice on a treasury account is privileged — it must land
+	# in the audit trail, like transfer_between_system_wallets, not just app logs.
+	assert 'audit_log(\n\t\t"funding_invoice"' in API_PY or '"funding_invoice"' in API_PY
+
+
+def test_ibex_status_is_io_free():
+	# invoice_settled is the money-critical receipt decision; it must stay pure
+	# (no frappe/requests/pymongo) so it can be unit-tested against fixtures.
+	for banned in ("import frappe", "import requests", "import pymongo"):
+		assert banned not in IBEX_STATUS_PY, f"ibex_status must stay IO-free: found {banned}"
+	assert "def invoice_settled(" in IBEX_STATUS_PY
 
 
 def test_funding_ui_is_wired_and_usd_usdt_only():

--- a/admin_panel/tests/test_system_accounts_page_contract.py
+++ b/admin_panel/tests/test_system_accounts_page_contract.py
@@ -6,6 +6,7 @@ cap and a role-wallet-only guard, and every attempt lands in the
 append-only System Transfer Log.
 """
 
+import ast
 import json
 import re
 from pathlib import Path
@@ -178,6 +179,35 @@ def test_funding_invoice_generation_is_audited():
 	# failure (e.g. the doctype not yet migrated) must never strand the invoice by
 	# hiding its bolt11 — the audit write is wrapped and falls through to return.
 	assert "funding_invoice audit write failed" in API_PY
+
+
+def test_funding_audit_best_effort_return_survives_insert_failure():
+	# The audit write is the ONE control preventing a stranded irreversible LN
+	# invoice, so a string grep isn't enough — it would pass even if the except
+	# re-raised or the bolt11 return moved inside the try. There's no frappe test
+	# harness here (the module imports frappe at top level), so assert the two
+	# failure modes structurally via AST instead: (1) the audit except must not
+	# re-raise, and (2) the bolt11 return must be a sibling AFTER the audit
+	# try/except, so it is reached on fallthrough when the insert throws.
+	fn = next(
+		n
+		for n in ast.walk(ast.parse(API_PY))
+		if isinstance(n, ast.FunctionDef) and n.name == "create_funding_invoice"
+	)
+	body = fn.body
+	# the audit try is the one whose body creates the System Funding Log row
+	# (create_funding_invoice also has an earlier try around float(amount_usd))
+	try_idx = next(
+		i for i, s in enumerate(body) if isinstance(s, ast.Try) and "System Funding Log" in ast.dump(s)
+	)
+	audit_try = body[try_idx]
+	for handler in audit_try.handlers:
+		assert not any(
+			isinstance(x, ast.Raise) for x in ast.walk(handler)
+		), "the funding-audit except must not re-raise — it would strand the created invoice"
+	assert any(
+		isinstance(s, ast.Return) and "bolt11" in ast.dump(s) for s in body[try_idx + 1 :]
+	), "the bolt11 return must follow the audit try/except, not sit inside it"
 
 
 def test_funding_log_doctype_is_append_only():

--- a/admin_panel/tests/test_system_accounts_page_contract.py
+++ b/admin_panel/tests/test_system_accounts_page_contract.py
@@ -107,6 +107,37 @@ def test_activity_endpoint_revalidates_wallet_membership():
 	assert "frappe.PermissionError" in API_PY
 
 
+def test_funding_invoice_is_financial_gated_membership_checked_and_capped():
+	stack = "@frappe.whitelist()\n@require_financial()\n@handle_api_errors\ndef create_funding_invoice("
+	assert (
+		stack in API_PY
+	), "create_funding_invoice must be whitelisted + require_financial + handle_api_errors"
+	# reuses the sanctioned add_invoice write — no new IBEX write path
+	assert "IbexClient().add_invoice(" in API_PY
+	# membership re-derived server-side — not a generate-for-any-wallet proxy
+	assert '"Not a system-account wallet"' in API_PY
+	# fat-finger ceiling: configurable AND actually compared, not just referenced
+	assert "system_funding_cap_usd" in API_PY
+	assert "DEFAULT_FUNDING_CAP_USD" in API_PY
+	assert "exceeds the funding cap" in API_PY
+	# returns only display fields — never the raw IBEX invoice blob
+	assert '"invoice": invoice' not in API_PY
+
+
+def test_wallet_balance_read_is_financial_gated_and_membership_checked():
+	stack = "@frappe.whitelist()\n@require_financial()\n@handle_api_errors\ndef get_system_wallet_balance("
+	assert stack in API_PY
+	assert '"Not a system-account wallet"' in API_PY
+
+
+def test_funding_ui_is_wired_and_usd_usdt_only():
+	assert "admin_panel.api.system_accounts.create_funding_invoice" in PAGE_JS
+	assert "admin_panel.api.system_accounts.get_system_wallet_balance" in PAGE_JS
+	assert "sa-fund-btn" in PAGE_JS
+	# Fund is only offered on USD/USDT rows — BTC uses a different rail
+	assert 'w.currency === "USD" || w.currency === "USDT"' in PAGE_JS
+
+
 def test_ibex_client_write_surface_is_exactly_the_two_invoice_calls():
 	assert '"/v2/invoice/add"' in IBEX_PY
 	assert '"/v2/invoice/pay"' in IBEX_PY

--- a/admin_panel/tests/test_system_accounts_page_contract.py
+++ b/admin_panel/tests/test_system_accounts_page_contract.py
@@ -15,6 +15,7 @@ API_PY = (ADMIN_PANEL / "api" / "system_accounts.py").read_text()
 IBEX_PY = (ADMIN_PANEL / "api" / "ibex_client.py").read_text()
 PAGE_JS = (ADMIN_PANEL / "admin_panel" / "page" / "system_accounts" / "system_accounts.js").read_text()
 SETUP_PY = (ADMIN_PANEL / "admin_panel" / "setup.py").read_text()
+CENSUS_PY = (ADMIN_PANEL / "api" / "census_core.py").read_text()
 
 
 def test_read_endpoints_carry_the_financial_gate():
@@ -136,6 +137,16 @@ def test_funding_ui_is_wired_and_usd_usdt_only():
 	assert "sa-fund-btn" in PAGE_JS
 	# Fund is only offered on USD/USDT rows — BTC uses a different rail
 	assert 'w.currency === "USD" || w.currency === "USDT"' in PAGE_JS
+
+
+def test_rewards_is_a_first_class_system_role():
+	# a real role=rewards treasury account must be enumerated like bankowner/
+	# funder/dealer — in the system-role set + ordering, the page's role labels,
+	# and the census system-vs-customer classification (never counted a customer).
+	assert '"rewards"' in API_PY
+	assert '"rewards": 3' in API_PY  # ordered after dealer, before watchlist
+	assert 'rewards: "Rewards"' in PAGE_JS
+	assert '"rewards"' in CENSUS_PY
 
 
 def test_ibex_client_write_surface_is_exactly_the_two_invoice_calls():

--- a/admin_panel/tests/test_system_accounts_page_contract.py
+++ b/admin_panel/tests/test_system_accounts_page_contract.py
@@ -163,7 +163,31 @@ def test_funding_receipt_is_invoice_settlement_not_balance_delta():
 def test_funding_invoice_generation_is_audited():
 	# Generating an LN invoice on a treasury account is privileged — it must land
 	# in the audit trail, like transfer_between_system_wallets, not just app logs.
-	assert 'audit_log(\n\t\t"funding_invoice"' in API_PY or '"funding_invoice"' in API_PY
+	assert '"funding_invoice"' in API_PY
+	# The audit Comment's reference_name is a Dynamic Link — it only persists
+	# against a REAL doctype row. A row is inserted in the append-only System
+	# Funding Log and audit_log points at THAT row (never the fabricated
+	# "System Wallet", which is not a doctype and would fail link validation,
+	# silently dropping the audit entry).
+	assert '"doctype": "System Funding Log"' in API_PY, "must insert a real System Funding Log row"
+	assert '"System Funding Log",\n\t\tlog.name,' in API_PY, "audit_log must reference the inserted row"
+	assert '"System Wallet"' not in API_PY, "audit must not reference the non-existent System Wallet doctype"
+
+
+def test_funding_log_doctype_is_append_only():
+	# One row per funding invoice, and read-only via the desk (no New button, no
+	# write/create/delete perms) — same append-only guarantees as the transfer log.
+	dt = json.loads(
+		(
+			ADMIN_PANEL / "admin_panel" / "doctype" / "system_funding_log" / "system_funding_log.json"
+		).read_text()
+	)
+	assert dt["name"] == "System Funding Log"
+	assert dt["in_create"] == 1  # no desk New button
+	for perm in dt["permissions"]:
+		assert (
+			not perm.get("write") and not perm.get("create") and not perm.get("delete")
+		), f"System Funding Log must be read-only via desk: {perm}"
 
 
 def test_ibex_status_is_io_free():


### PR DESCRIPTION
## What

Enhances the **System Accounts** page so operators can fund the treasury role wallets (bankowner / funder / dealer / rewards) from the UI, instead of hand-generating IBEX invoices over SSH.

Each USD/USDT wallet row gets a **Fund** button → a dialog that generates a Lightning receive invoice on that wallet's IBEX account. The invoice is copyable, has an "Open in wallet" link, shows a live ~60s countdown (denominated IBEX receive invoices are hub-capped at ~60s) with bounded auto-regeneration, and polls the wallet balance to confirm receipt.

## Changes

- **`create_funding_invoice(wallet_id, amount_usd)`** — inbound cousin of `transfer_between_system_wallets`. `@require_financial`, membership re-derived server-side, USD/USDT only, fat-finger cap (`system_funding_cap_usd`, default \$100k), reuses the sanctioned `add_invoice` (`/v2/invoice/add`) write — no new IBEX write path — and returns only the bolt11 + display fields, never the raw IBEX blob.
- **`get_system_wallet_balance(wallet_id)`** — cheap single-wallet read for the receipt poll.
- **`rewards` promoted to a first-class system role** — added to `SYSTEM_ROLES` in both `system_accounts.py` (card + Fund + ordering after dealer) and `census_core.py` (classified as a system account, not a customer, so the wallet census doesn't miscount its treasury wallet).
- Page **Fund** button (USD/USDT rows only) + funding dialog; "Rewards" label + chip.
- Contract tests extended: funding endpoint gate/membership/cap/no-leak, balance-read gate, Fund UI wiring, and rewards-first-class across all sites.

## Not included

- **QR (scan-to-pay)** — the frappe runtime ships no QR *generator* (only a camera scanner), so a QR needs a vendored JS lib or a Python `qrcode` dep. Deferred as a fast-follow; the MVP handles copy-paste / open-in-wallet funding.

## Testing

- ruff 0.8.1 lint + format clean; prettier 2.7.1 clean; **32 tests pass** (system-accounts contract + census core).
- The IBEX `add_invoice` contract this reuses was verified live: a \$2000 USDT invoice on the bankowner account returned `amount: 2000, currencyId: 29` with a 60s expiry.
- The frappe endpoints want the test-env deploy to exercise end-to-end (no local frappe runtime) — hence test-first below.

## Deploy

Frappe path — merge → `v*` tag → GHCR → deployments erp-bump → `make erp` on **test** first (verify on erp.test with a small real invoice), then prod. **Requires a migration** — the review-fix rounds added a `System Funding Log` doctype (append-only funding audit trail), so `make erp` must run `bench migrate` to create its table. The invoice path tolerates the pre-migrate window: the audit write is best-effort and never blocks returning the bolt11. Optional config: site_config `system_funding_cap_usd`.

## Review

Ran through `simon-review-fix` (3 rounds). Fixes applied: receipt confirmation now polls **this invoice's IBEX settlement by payment hash** (`get_funding_invoice_status` + IO-free `ibex_status.invoice_settled`) instead of a wallet-balance delta — the old heuristic would have false-fired on bankowner, whose float grows with every cashout; the receipt poll is bounded; funding invoice generation is audited to the append-only `System Funding Log`; and the audit write is best-effort so a pre-migrate/DB failure can never strand a created invoice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
