### PR TITLE
feat(fygaro): per-level daily top-up limit settings (L1 $125 / L2 $1000 / L3 $2500)

### DIFF
--- a/admin_panel/admin_panel/doctype/fygaro_settings/fygaro_settings.json
+++ b/admin_panel/admin_panel/doctype/fygaro_settings/fygaro_settings.json
@@ -15,7 +15,11 @@
   "auto_credit_section",
   "auto_credit_enabled",
   "auto_credit_limit",
-  "minimum_topup"
+  "minimum_topup",
+  "daily_limits_section",
+  "l1_daily_limit",
+  "l2_daily_limit",
+  "l3_daily_limit"
  ],
  "fields": [
   {
@@ -88,12 +92,38 @@
    "fieldname": "minimum_topup",
    "fieldtype": "Currency",
    "label": "Minimum Top-Up (USD)"
+  },
+  {
+   "fieldname": "daily_limits_section",
+   "fieldtype": "Section Break",
+   "label": "Daily Top-Up Limits (per account level)"
+  },
+  {
+   "default": "125.00",
+   "description": "Maximum gross card top-up per rolling 24h for Level 1 accounts (USD). Payments that would exceed it go to manual review.",
+   "fieldname": "l1_daily_limit",
+   "fieldtype": "Currency",
+   "label": "L1 Daily Limit (USD)"
+  },
+  {
+   "default": "1000.00",
+   "description": "Maximum gross card top-up per rolling 24h for Level 2 accounts (USD).",
+   "fieldname": "l2_daily_limit",
+   "fieldtype": "Currency",
+   "label": "L2 Daily Limit (USD)"
+  },
+  {
+   "default": "2500.00",
+   "description": "Maximum gross card top-up per rolling 24h for Level 3 (Business) accounts (USD).",
+   "fieldname": "l3_daily_limit",
+   "fieldtype": "Currency",
+   "label": "L3 Daily Limit (USD)"
   }
  ],
  "index_web_pages_for_search": 0,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-10 00:00:00.000000",
+ "modified": "2026-08-14 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Admin Panel",
  "name": "Fygaro Settings",

--- a/admin_panel/admin_panel/doctype/fygaro_settings/fygaro_settings.py
+++ b/admin_panel/admin_panel/doctype/fygaro_settings/fygaro_settings.py
@@ -27,3 +27,8 @@ class FygaroSettings(Document):
 
 		if frappe.utils.flt(self.auto_credit_limit) < frappe.utils.flt(self.minimum_topup):
 			frappe.throw("Auto-Credit Limit cannot be below the Minimum Top-Up.")
+
+		# Zero is a deliberate "no card top-ups for this level"; negative is a typo.
+		for fieldname in ("l1_daily_limit", "l2_daily_limit", "l3_daily_limit"):
+			if frappe.utils.flt(self.get(fieldname)) < 0:
+				frappe.throw(f"{self.meta.get_label(fieldname)} cannot be negative.")

--- a/admin_panel/patches.txt
+++ b/admin_panel/patches.txt
@@ -4,3 +4,4 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
+admin_panel.patches.set_fygaro_daily_limit_defaults

--- a/admin_panel/patches/set_fygaro_daily_limit_defaults.py
+++ b/admin_panel/patches/set_fygaro_daily_limit_defaults.py
@@ -12,15 +12,24 @@ import frappe
 # Only NULL values are touched: an operator-set value — including a deliberate
 # 0 meaning "no card top-ups for this level" — is never overwritten, so the
 # patch stays safe to re-run.
+#
+# The raw tabSingles rows are read via get_singles_dict, NOT get_single_value:
+# v15's get_single_value casts the fetched value by fieldtype before returning
+# it, and the Currency cast collapses NULL to 0.0 — a missing value becomes
+# indistinguishable from a deliberate operator 0, and a `is None` guard on the
+# cast value never fires. get_singles_dict returns the stored rows uncast: a
+# field with no row is simply absent (None), while an operator 0 is stored as
+# "0" and correctly preserved.
 
 DEFAULTS = {
-    "l1_daily_limit": 125.00,
-    "l2_daily_limit": 1000.00,
-    "l3_daily_limit": 2500.00,
+	"l1_daily_limit": 125.00,
+	"l2_daily_limit": 1000.00,
+	"l3_daily_limit": 2500.00,
 }
 
 
 def execute():
-    for fieldname, default in DEFAULTS.items():
-        if frappe.db.get_single_value("Fygaro Settings", fieldname) is None:
-            frappe.db.set_single_value("Fygaro Settings", fieldname, default)
+	stored = frappe.db.get_singles_dict("Fygaro Settings")
+	for fieldname, default in DEFAULTS.items():
+		if stored.get(fieldname) is None:
+			frappe.db.set_single_value("Fygaro Settings", fieldname, default)

--- a/admin_panel/patches/set_fygaro_daily_limit_defaults.py
+++ b/admin_panel/patches/set_fygaro_daily_limit_defaults.py
@@ -1,0 +1,26 @@
+import frappe
+
+# Seed the per-level daily top-up limits on the Fygaro Settings single.
+#
+# Field defaults in the doctype JSON only apply when the document is saved
+# through the UI — a migrate alone leaves the new columns NULL in tabSingles.
+# The flash webhook fails closed on a missing limit (every payment drops to
+# manual review), so an operator forgetting to open-and-save the settings page
+# after this deploy would silently disable auto-credit. Seeding here makes the
+# deploy self-contained.
+#
+# Only NULL values are touched: an operator-set value — including a deliberate
+# 0 meaning "no card top-ups for this level" — is never overwritten, so the
+# patch stays safe to re-run.
+
+DEFAULTS = {
+    "l1_daily_limit": 125.00,
+    "l2_daily_limit": 1000.00,
+    "l3_daily_limit": 2500.00,
+}
+
+
+def execute():
+    for fieldname, default in DEFAULTS.items():
+        if frappe.db.get_single_value("Fygaro Settings", fieldname) is None:
+            frappe.db.set_single_value("Fygaro Settings", fieldname, default)

--- a/admin_panel/tests/test_fygaro_settings_daily_limits.py
+++ b/admin_panel/tests/test_fygaro_settings_daily_limits.py
@@ -8,7 +8,10 @@ is part of the contract too. Runs under plain ``pytest`` with no Frappe
 runtime, matching the existing contract-test style.
 """
 
+import importlib
 import json
+import sys
+import types
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -58,9 +61,93 @@ def test_seeding_patch_defaults_match_the_doctype_and_only_touch_null():
 	patch_src = (ADMIN_PANEL / "patches" / "set_fygaro_daily_limit_defaults.py").read_text()
 
 	for fieldname, default in EXPECTED_DEFAULTS.items():
-		assert f'"{fieldname}": {default.rstrip("0").rstrip(".") + ".00"}' in patch_src or (
+		assert (
 			f'"{fieldname}": {default}' in patch_src
 		), f"patch default for {fieldname} drifted from the doctype default"
 	# The patch must never overwrite an operator-set value — including a
 	# deliberate 0 meaning "no card top-ups for this level".
 	assert "is None" in patch_src
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests for the seeding patch. The patch imports frappe at module
+# level, so a stub is installed in sys.modules before the import — the same
+# no-Frappe-runtime approach as the other contract tests in this suite.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_module(name):
+	try:
+		__import__(name)
+	except ImportError:
+		sys.modules.setdefault(name, types.ModuleType(name))
+	return sys.modules[name]
+
+
+_frappe = _ensure_module("frappe")
+
+
+class SinglesStore:
+	"""Stand-in for frappe.db backed by a dict of raw tabSingles rows.
+
+	Values live as strings, exactly as tabSingles stores them: an
+	operator-set 0 is the string "0"; a never-saved field is simply absent.
+	"""
+
+	def __init__(self, rows=None):
+		self.rows = dict(rows or {})
+		self.writes = []
+
+	def get_singles_dict(self, doctype):
+		assert doctype == "Fygaro Settings"
+		return dict(self.rows)
+
+	def get_single_value(self, doctype, fieldname):
+		# Faithful to Frappe v15: get_single_value casts the fetched value by
+		# fieldtype before returning it, and the Currency cast collapses a
+		# missing value (NULL) to 0.0. This is exactly why the patch must not
+		# use this API for its NULL guard — `0.0 is None` is never True.
+		assert doctype == "Fygaro Settings"
+		value = self.rows.get(fieldname)
+		return float(value) if value is not None else 0.0
+
+	def set_single_value(self, doctype, fieldname, value):
+		assert doctype == "Fygaro Settings"
+		self.rows[fieldname] = str(value)
+		self.writes.append((fieldname, value))
+
+
+def _run_patch(monkeypatch, db):
+	monkeypatch.setattr(_frappe, "db", db, raising=False)
+	patch = importlib.import_module("admin_panel.patches.set_fygaro_daily_limit_defaults")
+	patch.execute()
+	return db
+
+
+def test_patch_seeds_all_three_defaults_on_a_fresh_migrate(monkeypatch):
+	"""A freshly migrated site has no tabSingles rows — all three must be seeded."""
+	db = _run_patch(monkeypatch, SinglesStore())
+
+	assert db.writes == [
+		("l1_daily_limit", 125.00),
+		("l2_daily_limit", 1000.00),
+		("l3_daily_limit", 2500.00),
+	]
+
+	# Re-running the patch against the now-seeded store writes nothing.
+	db.writes.clear()
+	importlib.import_module("admin_panel.patches.set_fygaro_daily_limit_defaults").execute()
+	assert db.writes == []
+
+
+def test_patch_never_overwrites_operator_values_including_zero(monkeypatch):
+	"""Operator-set values — including a deliberate 0 — must survive re-runs."""
+	operator_rows = {
+		"l1_daily_limit": "0",  # deliberate "no card top-ups for L1"
+		"l2_daily_limit": "500.00",
+		"l3_daily_limit": "9999.99",
+	}
+	db = _run_patch(monkeypatch, SinglesStore(operator_rows))
+
+	assert db.writes == []
+	assert db.rows == operator_rows

--- a/admin_panel/tests/test_fygaro_settings_daily_limits.py
+++ b/admin_panel/tests/test_fygaro_settings_daily_limits.py
@@ -1,0 +1,66 @@
+"""Contract tests for the per-level daily top-up limits on Fygaro Settings.
+
+The l1/l2/l3_daily_limit field names and their semantics (gross USD per
+rolling 24h, keyed by account level) are a contract shared with the flash
+webhook's credit gate — flash fails closed (every payment drops to manual
+review) if any of the three is missing, which is why the seeding patch below
+is part of the contract too. Runs under plain ``pytest`` with no Frappe
+runtime, matching the existing contract-test style.
+"""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ADMIN_PANEL = REPO_ROOT / "admin_panel"
+FYGARO_SETTINGS_DIR = ADMIN_PANEL / "admin_panel" / "doctype" / "fygaro_settings"
+
+EXPECTED_DEFAULTS = {
+	"l1_daily_limit": "125.00",
+	"l2_daily_limit": "1000.00",
+	"l3_daily_limit": "2500.00",
+}
+
+
+def load_doctype():
+	return json.loads((FYGARO_SETTINGS_DIR / "fygaro_settings.json").read_text())
+
+
+def test_doctype_defines_all_three_daily_limits_as_currency_with_defaults():
+	doctype = load_doctype()
+	fields = {f["fieldname"]: f for f in doctype["fields"]}
+
+	for fieldname, default in EXPECTED_DEFAULTS.items():
+		assert fieldname in fields, f"{fieldname} missing from Fygaro Settings"
+		assert fields[fieldname]["fieldtype"] == "Currency"
+		assert fields[fieldname]["default"] == default
+		# Each limit must also be placed in the layout, or the operator cannot
+		# see or tune it from the settings page.
+		assert fieldname in doctype["field_order"]
+
+
+def test_validate_rejects_negative_daily_limits():
+	controller = (FYGARO_SETTINGS_DIR / "fygaro_settings.py").read_text()
+	normalized = " ".join(controller.split())
+
+	assert '("l1_daily_limit", "l2_daily_limit", "l3_daily_limit")' in normalized
+	assert "cannot be negative" in controller
+
+
+def test_seeding_patch_is_registered_post_model_sync():
+	patches = (ADMIN_PANEL / "patches.txt").read_text()
+	post = patches.split("[post_model_sync]", 1)[1]
+
+	assert "admin_panel.patches.set_fygaro_daily_limit_defaults" in post
+
+
+def test_seeding_patch_defaults_match_the_doctype_and_only_touch_null():
+	patch_src = (ADMIN_PANEL / "patches" / "set_fygaro_daily_limit_defaults.py").read_text()
+
+	for fieldname, default in EXPECTED_DEFAULTS.items():
+		assert f'"{fieldname}": {default.rstrip("0").rstrip(".") + ".00"}' in patch_src or (
+			f'"{fieldname}": {default}' in patch_src
+		), f"patch default for {fieldname} drifted from the doctype default"
+	# The patch must never overwrite an operator-set value — including a
+	# deliberate 0 meaning "no card top-ups for this level".
+	assert "is None" in patch_src


### PR DESCRIPTION
## What

Adds the operator-tunable per-level daily card top-up caps that lnflash/flash#482 reads through the Fygaro Settings single:

- `l1_daily_limit` / `l2_daily_limit` / `l3_daily_limit` (Currency, defaults 125 / 1000 / 2500) in a new **Daily Top-Up Limits** section on `/app/fygaro-settings`.
- Validation: negative limits rejected; **0 is allowed** and means "no card top-ups for this level".
- `post_model_sync` patch `set_fygaro_daily_limit_defaults` seeds the three values on migrate **only where NULL** — the flash webhook fails closed on a missing limit, so without the patch every payment would drop to manual review until an operator opened-and-saved the settings page. Operator-set values (including a deliberate 0) are never overwritten; the patch is safe to re-run.

## Deploy order

Deploy this (v-tag → `make erp`, migrate runs the patch) **before** lnflash/flash#482. Until flash deploys, the extra fields are inert.

## Tests

`admin_panel/tests/test_fygaro_settings_daily_limits.py` pins the doctype fields/defaults/layout, the negative-value validation, the patch registration, and default-drift between patch and doctype. Suite: 210 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nt7JxbX5W9o7viKegnXJPH